### PR TITLE
fix(recording): stabilize toolbar across display DPI changes

### DIFF
--- a/snow_shot/CMakeLists.txt
+++ b/snow_shot/CMakeLists.txt
@@ -3755,7 +3755,20 @@ if(SNOW_SHOT_BUILD_TESTS)
     target_compile_definitions(snow-shot-screen-recording-controller-tests PRIVATE
         snow_capture_last_error_message=test_recording_last_error_message)
     if(WIN32)
-        target_link_libraries(snow-shot-screen-recording-controller-tests PRIVATE user32 dwmapi)
+        target_link_libraries(snow-shot-screen-recording-controller-tests PRIVATE user32 dwmapi gdi32)
+        target_sources(snow-shot-screen-recording-controller-tests PRIVATE
+            tests/screen_recording_toolbar_display_tests.cpp)
+        add_test(NAME snow-shot-screen-recording-toolbar-display-tests
+            COMMAND snow-shot-screen-recording-controller-tests
+                --native-toolbar-display-only -platform windows)
+        add_test(NAME snow-shot-screen-recording-toolbar-ready-display-tests
+            COMMAND snow-shot-screen-recording-controller-tests
+                --native-toolbar-ready-display-only -platform windows)
+        set_tests_properties(snow-shot-screen-recording-toolbar-display-tests
+            snow-shot-screen-recording-toolbar-ready-display-tests PROPERTIES
+            LABELS "interactive;windows" RUN_SERIAL TRUE TIMEOUT 30 SKIP_RETURN_CODE 77
+            ENVIRONMENT "QT_QPA_PLATFORM=windows"
+            ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Qt6::Core>")
     endif()
     add_test(NAME snow-shot-screen-recording-controller-tests
         COMMAND snow-shot-screen-recording-controller-tests)
@@ -3826,6 +3839,12 @@ if(SNOW_SHOT_BUILD_TESTS)
         NAME snow-shot-screen-recording-area-window-tests
         COMMAND snow-shot-screen-recording-area-window-tests
     )
+    if(WIN32)
+        add_test(NAME snow-shot-screen-recording-area-native-tests
+            COMMAND snow-shot-screen-recording-area-window-tests --native-geometry-only -platform windows)
+        set_tests_properties(snow-shot-screen-recording-area-native-tests PROPERTIES
+            LABELS "interactive;windows" RUN_SERIAL TRUE TIMEOUT 45)
+    endif()
     set_tests_properties(snow-shot-screen-recording-area-window-tests PROPERTIES
         ENVIRONMENT
             "${_SNOW_SHOT_OFFSCREEN_QPA_ENVIRONMENT};QT_SCALE_FACTOR=1.25"

--- a/snow_shot/include/snow_shot/presentation/screenrecordingareawindow.h
+++ b/snow_shot/include/snow_shot/presentation/screenrecordingareawindow.h
@@ -4,6 +4,7 @@
 #include "snow_shot/presentation/screenshottoolpalette.h"
 
 #include <QRect>
+#include <QMarginsF>
 #include <QRectF>
 #include <QWidget>
 
@@ -39,10 +40,17 @@ class ScreenRecordingAreaWindow final : public QWidget {
 
   signals:
     void physicalRegionChanged(const QRect& region);
+    void regionInteractionStarted();
+    void regionInteractionFinished();
+    void closeRequested();
     void drawingDeactivationRequested();
     void drawingWheelRequested(int direction);
 
   protected:
+    bool event(QEvent* event) override;
+    void moveEvent(QMoveEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
+    void closeEvent(QCloseEvent* event) override;
     bool eventFilter(QObject* watched, QEvent* event) override;
     bool nativeEvent(const QByteArray& eventType, void* message, qintptr* result) override;
     void paintEvent(QPaintEvent* event) override;
@@ -55,8 +63,12 @@ class ScreenRecordingAreaWindow final : public QWidget {
     void applyNativePassThrough(bool enabled);
     [[nodiscard]] bool regionEditingEnabled() const;
     [[nodiscard]] Qt::Edges resizeEdgesAt(const QPointF& position) const;
-    bool handleRegionMouseEvent(QObject* watched, QEvent* event);
-    void cancelRegionGesture();
+    void cancelRegionInteraction();
+    void finishRegionInteraction();
+    void beginRegionInteraction();
+    void synchronizeWindowGeometry();
+    void scheduleGeometrySynchronization();
+    void layoutSelection();
 
     QRectF m_frameRect;
     QRectF m_selectionRect;
@@ -66,12 +78,10 @@ class ScreenRecordingAreaWindow final : public QWidget {
     InputMode m_inputMode = InputMode::PassThrough;
     bool m_drawingBlocked = false;
     bool m_gestureInProgress = false;
-    bool m_regionGestureInProgress = false;
-    Qt::Edges m_resizeEdges;
-    QPointF m_regionGestureStart;
-    QRect m_regionGestureRect;
-    QRect m_regionGestureBounds;
-    qreal m_regionGestureScale = 1.0;
+    bool m_regionInteractionActive = false;
+    bool m_settingRegion = false;
+    bool m_geometrySyncPending = false;
+    QMarginsF m_physicalInsets;
     std::unique_ptr<SnowCanvasRuntime> m_canvasRuntime;
     SnowCanvasWidget* m_canvas = nullptr;
 };

--- a/snow_shot/include/snow_shot/presentation/screenrecordingtoolbarwindow.h
+++ b/snow_shot/include/snow_shot/presentation/screenrecordingtoolbarwindow.h
@@ -13,11 +13,20 @@ class ScreenRecordingToolbarWindow final : public ScreenshotFloatingToolPaletteW
 
     void placeForPhysicalRegion(const QRect& physicalRegion);
     void showAndActivate();
+    void beginRegionInteraction();
+    void endRegionInteraction(const QRect& physicalRegion);
+
+  signals:
+    void closeRequested();
+
+  protected:
+    void closeEvent(QCloseEvent* event) override;
 
   private:
     QRect m_physicalRegion;
     bool m_manuallyDragged = false;
     bool m_placing = false;
+    bool m_regionInteractionActive = false;
 };
 
 #endif // SNOW_SHOT_PRESENTATION_SCREENRECORDINGTOOLBARWINDOW_H

--- a/snow_shot/src/presentation/recording/screenrecordingareawindow.cpp
+++ b/snow_shot/src/presentation/recording/screenrecordingareawindow.cpp
@@ -15,6 +15,11 @@
 #include <QScreen>
 #include <QShowEvent>
 #include <QWheelEvent>
+#include <QWindow>
+#include <QMoveEvent>
+#include <QResizeEvent>
+#include <QCloseEvent>
+#include <QScopedValueRollback>
 
 #if defined(Q_OS_WIN) || defined(_WIN32)
 #ifndef NOMINMAX
@@ -28,11 +33,30 @@ constexpr QColor kIdleColor(0x40, 0x96, 0xff);
 constexpr QColor kRecordingColor(0xf5, 0x22, 0x2d);
 constexpr QColor kPausedColor(0xfa, 0xad, 0x14);
 constexpr qreal kResizeHitWidth = 6.0;
+constexpr int kFrameInset = snow_shot::presentation::recording::screenRecordingPhysicalFrameInset;
+
+QRect nativeClientGeometry(const QWidget& window) {
+#if defined(Q_OS_WIN) || defined(_WIN32)
+    if (QGuiApplication::platformName() == QStringLiteral("windows") &&
+        window.internalWinId() != 0) {
+        const HWND handle = reinterpret_cast<HWND>(window.internalWinId());
+        RECT client{};
+        POINT origin{};
+        if (GetClientRect(handle, &client) && ClientToScreen(handle, &origin)) {
+            return QRect(origin.x, origin.y, client.right - client.left,
+                         client.bottom - client.top);
+        }
+    }
+#else
+    Q_UNUSED(window);
+#endif
+    return {};
+}
 } // namespace
 
 ScreenRecordingAreaWindow::ScreenRecordingAreaWindow(QWidget* parent)
     : QWidget(parent, Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint |
-                          Qt::MSWindowsFixedSizeDialogHint | Qt::NoDropShadowWindowHint),
+                          Qt::NoDropShadowWindowHint),
       m_canvasRuntime(std::make_unique<SnowCanvasRuntime>()),
       m_canvas(new SnowCanvasWidget(*m_canvasRuntime, this)) {
     setAttribute(Qt::WA_TranslucentBackground, true);
@@ -47,6 +71,7 @@ ScreenRecordingAreaWindow::ScreenRecordingAreaWindow(QWidget* parent)
     m_canvas->setClearBackgroundEnabled(false);
     m_canvas->setWheelZoomEnabled(false);
     m_canvas->setCanvasContentVisible(true);
+    static_cast<void>(m_canvas->setCanvasTool(SnowCanvasTool::Select));
     m_canvas->installEventFilter(this);
     snow_shot::presentation::applyScreenshotCanvasToolStyles(
         *m_canvas, snow_shot::presentation::screenshotCanvasToolStyleDefaults());
@@ -60,9 +85,10 @@ QRect ScreenRecordingAreaWindow::physicalRegion() const {
 }
 
 void ScreenRecordingAreaWindow::setPhysicalRegion(const QRect& region) {
-    if (!region.isValid() || region.isEmpty()) {
+    if (region.width() < 2 || region.height() < 2) {
         return;
     }
+    const QScopedValueRollback<bool> settingRegion(m_settingRegion, true);
     const bool opensNewRegion = m_physicalRegion.isValid() && m_physicalRegion != region;
     m_physicalRegion = region;
     QScreen* screen = ScreenshotGeometryMapper::screenForPhysicalRect(region);
@@ -75,6 +101,25 @@ void ScreenRecordingAreaWindow::setPhysicalRegion(const QRect& region) {
     m_selectionRect = frameGeometry.selectionRect;
     m_paddingWidth = frameGeometry.paddingWidth;
     setGeometry(frameGeometry.windowGeometry);
+    m_physicalInsets = QMarginsF(m_selectionRect.left() * scale, m_selectionRect.top() * scale,
+                                 (width() - m_selectionRect.right()) * scale,
+                                 (height() - m_selectionRect.bottom()) * scale);
+#if defined(Q_OS_WIN) || defined(_WIN32)
+    if (QGuiApplication::platformName() == QStringLiteral("windows") && screen != nullptr) {
+        // Qt owns even the initial native placement. Its integer logical geometry can
+        // add a physical pixel of outer padding at fractional DPI; keep that padding
+        // outside the exact screenshot selection instead of competing with Qt via SetWindowPos.
+        const QPoint logicalOrigin = screen->geometry().topLeft();
+        const QPoint physicalOrigin =
+            ScreenshotGeometryMapper::physicalRectForScreen(*screen).topLeft();
+        const QPoint windowOrigin(physicalOrigin.x() + qRound((x() - logicalOrigin.x()) * scale),
+                                  physicalOrigin.y() + qRound((y() - logicalOrigin.y()) * scale));
+        const QPoint inset = region.topLeft() - windowOrigin;
+        m_physicalInsets =
+            QMarginsF(inset.x(), inset.y(), qRound(width() * scale) - inset.x() - region.width(),
+                      qRound(height() * scale) - inset.y() - region.height());
+    }
+#endif
     if (m_canvas != nullptr) {
         m_canvas->setGeometry(m_selectionRect.toAlignedRect());
         m_canvas->raise();
@@ -90,7 +135,7 @@ void ScreenRecordingAreaWindow::setRecordingState(ScreenshotToolPalette::Recordi
         return;
     }
     m_state = state;
-    cancelRegionGesture();
+    cancelRegionInteraction();
     applyInputMode();
 }
 
@@ -100,7 +145,7 @@ void ScreenRecordingAreaWindow::setInputMode(InputMode mode) {
         return;
     }
     m_inputMode = mode;
-    cancelRegionGesture();
+    cancelRegionInteraction();
     m_gestureInProgress = false;
     applyInputMode();
 }
@@ -114,7 +159,7 @@ void ScreenRecordingAreaWindow::setDrawingBlocked(bool blocked) {
         return;
     }
     m_drawingBlocked = blocked;
-    cancelRegionGesture();
+    cancelRegionInteraction();
     m_gestureInProgress = false;
     applyInputMode();
 }
@@ -132,9 +177,8 @@ QRect ScreenRecordingAreaWindow::canvasGeometry() const {
 }
 
 bool ScreenRecordingAreaWindow::eventFilter(QObject* watched, QEvent* event) {
-    if ((watched == this || watched == m_canvas) && event != nullptr &&
-        handleRegionMouseEvent(watched, event)) {
-        return true;
+    if (watched == this && event != nullptr && event->type() == QEvent::Hide) {
+        cancelRegionInteraction();
     }
     if (watched != m_canvas || event == nullptr || m_inputMode != InputMode::Drawing ||
         m_drawingBlocked) {
@@ -194,6 +238,7 @@ bool ScreenRecordingAreaWindow::eventFilter(QObject* watched, QEvent* event) {
 void ScreenRecordingAreaWindow::showEvent(QShowEvent* event) {
     QWidget::showEvent(event);
     applyInputMode();
+    scheduleGeometrySynchronization();
 }
 
 void ScreenRecordingAreaWindow::applyInputMode() {
@@ -217,7 +262,8 @@ void ScreenRecordingAreaWindow::applyInputMode() {
 }
 
 bool ScreenRecordingAreaWindow::regionEditingEnabled() const {
-    return m_state == ScreenshotToolPalette::RecordingState::Idle && !m_drawingBlocked;
+    return m_inputMode == InputMode::RegionEditing &&
+           m_state == ScreenshotToolPalette::RecordingState::Idle && !m_drawingBlocked;
 }
 
 Qt::Edges ScreenRecordingAreaWindow::resizeEdgesAt(const QPointF& position) const {
@@ -225,8 +271,8 @@ Qt::Edges ScreenRecordingAreaWindow::resizeEdgesAt(const QPointF& position) cons
         return {};
     }
     Qt::Edges edges;
-    const qreal horizontalHitWidth = qMin(kResizeHitWidth, m_selectionRect.width() / 2.0);
-    const qreal verticalHitWidth = qMin(kResizeHitWidth, m_selectionRect.height() / 2.0);
+    const qreal horizontalHitWidth = qMin(kResizeHitWidth, m_selectionRect.width() / 4.0);
+    const qreal verticalHitWidth = qMin(kResizeHitWidth, m_selectionRect.height() / 4.0);
     if (position.x() <= m_selectionRect.left() + horizontalHitWidth) {
         edges |= Qt::LeftEdge;
     } else if (position.x() >= m_selectionRect.right() - horizontalHitWidth) {
@@ -240,144 +286,223 @@ Qt::Edges ScreenRecordingAreaWindow::resizeEdgesAt(const QPointF& position) cons
     return edges;
 }
 
-void ScreenRecordingAreaWindow::cancelRegionGesture() {
-    m_regionGestureInProgress = false;
-    m_resizeEdges = {};
-    if (QWidget::mouseGrabber() == this) {
-        releaseMouse();
+void ScreenRecordingAreaWindow::beginRegionInteraction() {
+    if (!regionEditingEnabled() || m_regionInteractionActive) {
+        return;
     }
-    unsetCursor();
-    if (m_canvas != nullptr) {
-        m_canvas->unsetCursor();
+    m_regionInteractionActive = true;
+    emit regionInteractionStarted();
+}
+
+void ScreenRecordingAreaWindow::cancelRegionInteraction() {
+    if (!m_regionInteractionActive) {
+        return;
+    }
+#if defined(Q_OS_WIN) || defined(_WIN32)
+    if (QGuiApplication::platformName() == QStringLiteral("windows")) {
+        SendMessageW(reinterpret_cast<HWND>(internalWinId()), WM_CANCELMODE, 0, 0);
+        // The system loop owns completion, including cancellation. Keep the toolbar
+        // hidden until WM_EXITSIZEMOVE, after any final geometry has been applied.
+        return;
+    }
+#endif
+    finishRegionInteraction();
+}
+
+void ScreenRecordingAreaWindow::finishRegionInteraction() {
+    if (!m_regionInteractionActive) {
+        return;
+    }
+    synchronizeWindowGeometry();
+    m_regionInteractionActive = false;
+    emit regionInteractionFinished();
+}
+
+void ScreenRecordingAreaWindow::layoutSelection() {
+    const qreal scale = devicePixelRatioF();
+    QRectF selection = QRectF(rect()).marginsRemoved(
+        QMarginsF(m_physicalInsets.left() / scale, m_physicalInsets.top() / scale,
+                  m_physicalInsets.right() / scale, m_physicalInsets.bottom() / scale));
+    const qreal frameInset = kFrameInset / scale;
+    QRectF frame = selection.adjusted(-frameInset, -frameInset, frameInset, frameInset);
+    const qreal padding = 1.0 / scale;
+    const auto nativeGeometry = snow_shot::presentation::recording::screenRecordingObservedGeometry(
+        nativeClientGeometry(*this), scale, m_physicalInsets.toMargins());
+    if (nativeGeometry.physicalRegion.isValid()) {
+        selection = nativeGeometry.selectionRect;
+        frame = nativeGeometry.frameRect;
+    }
+    if (m_selectionRect == selection && m_frameRect == frame && m_paddingWidth == padding) {
+        return;
+    }
+    m_selectionRect = selection;
+    m_frameRect = frame;
+    m_paddingWidth = padding;
+    m_canvas->setGeometry(m_selectionRect.toAlignedRect());
+    update();
+}
+
+void ScreenRecordingAreaWindow::scheduleGeometrySynchronization() {
+    if (m_geometrySyncPending) {
+        return;
+    }
+    m_geometrySyncPending = true;
+    QMetaObject::invokeMethod(
+        this,
+        [this]() {
+            m_geometrySyncPending = false;
+            synchronizeWindowGeometry();
+        },
+        Qt::QueuedConnection);
+}
+
+void ScreenRecordingAreaWindow::synchronizeWindowGeometry() {
+    if (m_settingRegion || !m_physicalRegion.isValid()) {
+        return;
+    }
+#if defined(Q_OS_WIN) || defined(_WIN32)
+    // QWidget delivers its initial move/resize before applying geometry to a hidden HWND.
+    // The deferred observation after Show/WM_WINDOWPOSCHANGED sees the committed client pixels.
+    if (QGuiApplication::platformName() == QStringLiteral("windows") &&
+        !IsWindowVisible(reinterpret_cast<HWND>(internalWinId()))) {
+        return;
+    }
+#endif
+    layoutSelection();
+    const qreal scale = devicePixelRatioF();
+    const QScreen* currentScreen = screen();
+    const QPoint logicalOrigin =
+        currentScreen != nullptr ? currentScreen->geometry().topLeft() : QPoint();
+    const QPoint physicalOrigin =
+        currentScreen != nullptr
+            ? ScreenshotGeometryMapper::physicalRectForScreen(*currentScreen).topLeft()
+            : QPoint();
+    const QPointF selectionOrigin = QPointF(mapToGlobal(QPoint())) + m_selectionRect.topLeft();
+    QRect region(physicalOrigin.x() + qRound((selectionOrigin.x() - logicalOrigin.x()) * scale),
+                 physicalOrigin.y() + qRound((selectionOrigin.y() - logicalOrigin.y()) * scale),
+                 qRound(m_selectionRect.width() * scale), qRound(m_selectionRect.height() * scale));
+    const auto nativeGeometry = snow_shot::presentation::recording::screenRecordingObservedGeometry(
+        nativeClientGeometry(*this), scale, m_physicalInsets.toMargins());
+    if (nativeGeometry.physicalRegion.isValid()) {
+        region = nativeGeometry.physicalRegion;
+    }
+    if (region.width() >= 2 && region.height() >= 2 && region != m_physicalRegion) {
+        m_physicalRegion = region;
+        emit physicalRegionChanged(region);
     }
 }
 
-bool ScreenRecordingAreaWindow::handleRegionMouseEvent(QObject* watched, QEvent* event) {
-    if (event->type() == QEvent::Hide || event->type() == QEvent::WindowDeactivate ||
-        event->type() == QEvent::UngrabMouse) {
-        cancelRegionGesture();
-        return false;
+bool ScreenRecordingAreaWindow::event(QEvent* event) {
+    const bool handled = QWidget::event(event);
+    // A translucent backing-store flush can round the native surface by one pixel
+    // after the last resize event, without delivering another logical resize.
+    if (event->type() == QEvent::UpdateRequest || event->type() == QEvent::DevicePixelRatioChange ||
+        event->type() == QEvent::ScreenChangeInternal) {
+        synchronizeWindowGeometry();
     }
-    if (event->type() != QEvent::MouseButtonPress && event->type() != QEvent::MouseMove &&
-        event->type() != QEvent::MouseButtonRelease) {
-        return false;
-    }
-    if (!regionEditingEnabled() || m_gestureInProgress) {
-        return false;
-    }
-    auto* mouse = static_cast<QMouseEvent*>(event);
-    const QPointF position =
-        mouse->position() + (watched == m_canvas ? QPointF(m_canvas->pos()) : QPointF());
-    const Qt::Edges edges = resizeEdgesAt(position);
-    const bool movable =
-        m_inputMode == InputMode::RegionEditing && m_selectionRect.contains(position);
-    if (event->type() == QEvent::MouseButtonPress && mouse->button() == Qt::LeftButton &&
-        (edges != Qt::Edges() || movable)) {
-        QScreen* screen = ScreenshotGeometryMapper::screenForPhysicalRect(m_physicalRegion);
-        if (screen == nullptr) {
-            return false;
-        }
-        m_regionGestureBounds = ScreenshotGeometryMapper::physicalRectForScreen(*screen);
-        if (!m_regionGestureBounds.contains(m_physicalRegion)) {
-            // Preserve editable selections spanning monitors, including their existing extent
-            // if the display topology changed after the selection was opened.
-            for (const QScreen* attachedScreen : QGuiApplication::screens()) {
-                m_regionGestureBounds = m_regionGestureBounds.united(
-                    ScreenshotGeometryMapper::physicalRectForScreen(*attachedScreen));
-            }
-            m_regionGestureBounds = m_regionGestureBounds.united(m_physicalRegion);
-        }
-        m_regionGestureScale = screen->devicePixelRatio();
-        m_regionGestureStart = mouse->globalPosition();
-        m_regionGestureRect = m_physicalRegion;
-        m_resizeEdges = edges;
-        m_regionGestureInProgress = true;
-        grabMouse();
-        mouse->accept();
-        return true;
-    }
-    if (m_regionGestureInProgress &&
-        (event->type() == QEvent::MouseMove ||
-         (event->type() == QEvent::MouseButtonRelease && mouse->button() == Qt::LeftButton))) {
-        const QPointF logicalDelta = mouse->globalPosition() - m_regionGestureStart;
-        const QPoint delta(qRound(logicalDelta.x() * m_regionGestureScale),
-                           qRound(logicalDelta.y() * m_regionGestureScale));
-        QRect region = m_regionGestureRect;
-        const QRect bounds = m_regionGestureBounds;
-        if (m_resizeEdges == Qt::Edges()) {
-            region.moveLeft(qBound(bounds.left(), region.left() + delta.x(),
-                                   bounds.right() - region.width() + 1));
-            region.moveTop(qBound(bounds.top(), region.top() + delta.y(),
-                                  bounds.bottom() - region.height() + 1));
-        } else {
-            if (m_resizeEdges.testFlag(Qt::LeftEdge)) {
-                region.setLeft(
-                    qBound(bounds.left(), region.left() + delta.x(), region.right() - 1));
-            }
-            if (m_resizeEdges.testFlag(Qt::RightEdge)) {
-                region.setRight(
-                    qBound(region.left() + 1, region.right() + delta.x(), bounds.right()));
-            }
-            if (m_resizeEdges.testFlag(Qt::TopEdge)) {
-                region.setTop(qBound(bounds.top(), region.top() + delta.y(), region.bottom() - 1));
-            }
-            if (m_resizeEdges.testFlag(Qt::BottomEdge)) {
-                region.setBottom(
-                    qBound(region.top() + 1, region.bottom() + delta.y(), bounds.bottom()));
-            }
-        }
-        if (region != m_physicalRegion) {
-            setPhysicalRegion(region);
-            emit physicalRegionChanged(region);
-        }
-        if (event->type() == QEvent::MouseButtonRelease) {
-            cancelRegionGesture();
-        }
-        mouse->accept();
-        return true;
-    }
-    if (event->type() == QEvent::MouseMove) {
-        Qt::CursorShape cursor = Qt::ArrowCursor;
-        if ((edges.testFlag(Qt::LeftEdge) && edges.testFlag(Qt::TopEdge)) ||
-            (edges.testFlag(Qt::RightEdge) && edges.testFlag(Qt::BottomEdge))) {
-            cursor = Qt::SizeFDiagCursor;
-        } else if ((edges.testFlag(Qt::RightEdge) && edges.testFlag(Qt::TopEdge)) ||
-                   (edges.testFlag(Qt::LeftEdge) && edges.testFlag(Qt::BottomEdge))) {
-            cursor = Qt::SizeBDiagCursor;
-        } else if (edges.testFlag(Qt::LeftEdge) || edges.testFlag(Qt::RightEdge)) {
-            cursor = Qt::SizeHorCursor;
-        } else if (edges.testFlag(Qt::TopEdge) || edges.testFlag(Qt::BottomEdge)) {
-            cursor = Qt::SizeVerCursor;
-        } else if (movable) {
-            cursor = Qt::SizeAllCursor;
-        }
-        if (edges != Qt::Edges() || movable) {
-            setCursor(cursor);
-            m_canvas->setCursor(cursor);
-            mouse->accept();
-            return true;
-        }
-        unsetCursor();
-        m_canvas->unsetCursor();
-    }
-    return false;
+    return handled;
+}
+
+void ScreenRecordingAreaWindow::moveEvent(QMoveEvent* event) {
+    QWidget::moveEvent(event);
+    synchronizeWindowGeometry();
+}
+
+void ScreenRecordingAreaWindow::resizeEvent(QResizeEvent* event) {
+    QWidget::resizeEvent(event);
+    synchronizeWindowGeometry();
+}
+
+void ScreenRecordingAreaWindow::closeEvent(QCloseEvent* event) {
+    event->ignore();
+    emit closeRequested();
 }
 
 bool ScreenRecordingAreaWindow::nativeEvent(const QByteArray& eventType, void* message,
                                             qintptr* result) {
 #if defined(Q_OS_WIN) || defined(_WIN32)
-    const auto* nativeMessage = static_cast<MSG*>(message);
-    if (nativeMessage != nullptr && result != nullptr && nativeMessage->message == WM_NCHITTEST &&
-        m_inputMode == InputMode::PassThrough && regionEditingEnabled() &&
-        !m_regionGestureInProgress) {
-        RECT bounds{};
-        if (GetWindowRect(nativeMessage->hwnd, &bounds)) {
-            const int x = static_cast<short>(LOWORD(nativeMessage->lParam));
-            const int y = static_cast<short>(HIWORD(nativeMessage->lParam));
-            const QPointF local((x - bounds.left) / devicePixelRatioF(),
-                                (y - bounds.top) / devicePixelRatioF());
-            if (resizeEdgesAt(local) == Qt::Edges()) {
-                *result = HTTRANSPARENT;
+    const auto* msg = static_cast<MSG*>(message);
+    if (msg != nullptr && result != nullptr) {
+        if (msg->message == WM_WINDOWPOSCHANGED) {
+            scheduleGeometrySynchronization();
+        }
+        if (msg->message == WM_SYSCOMMAND && (!regionEditingEnabled() || !isVisible()) &&
+            ((msg->wParam & 0xfff0) == SC_MOVE || (msg->wParam & 0xfff0) == SC_SIZE)) {
+            *result = 0;
+            return true;
+        }
+        if (msg->message == WM_ENTERSIZEMOVE) {
+            beginRegionInteraction();
+        } else if (msg->message == WM_EXITSIZEMOVE) {
+            finishRegionInteraction();
+        } else if (msg->message == WM_GETMINMAXINFO && regionEditingEnabled()) {
+            auto* limits = reinterpret_cast<MINMAXINFO*>(msg->lParam);
+            limits->ptMinTrackSize = {
+                qRound(m_physicalInsets.left() + m_physicalInsets.right()) + 2,
+                qRound(m_physicalInsets.top() + m_physicalInsets.bottom()) + 2};
+            *result = 0;
+            return true;
+        } else if (msg->message == WM_NCHITTEST && !regionEditingEnabled()) {
+            *result =
+                m_inputMode == InputMode::Drawing && !m_drawingBlocked ? HTCLIENT : HTTRANSPARENT;
+            return true;
+        } else if (msg->message == WM_NCHITTEST && regionEditingEnabled()) {
+            POINT point{static_cast<short>(LOWORD(msg->lParam)),
+                        static_cast<short>(HIWORD(msg->lParam))};
+            ScreenToClient(msg->hwnd, &point);
+            const Qt::Edges edges = resizeEdgesAt(
+                QPointF(point.x / devicePixelRatioF(), point.y / devicePixelRatioF()));
+            const bool left = edges.testFlag(Qt::LeftEdge);
+            const bool right = edges.testFlag(Qt::RightEdge);
+            const bool top = edges.testFlag(Qt::TopEdge);
+            const bool bottom = edges.testFlag(Qt::BottomEdge);
+            *result = top      ? (left    ? HTTOPLEFT
+                                  : right ? HTTOPRIGHT
+                                          : HTTOP)
+                      : bottom ? (left    ? HTBOTTOMLEFT
+                                  : right ? HTBOTTOMRIGHT
+                                          : HTBOTTOM)
+                      : left   ? HTLEFT
+                      : right  ? HTRIGHT
+                               : HTCAPTION;
+            return true;
+        } else if (msg->message == WM_NCLBUTTONDOWN && regionEditingEnabled()) {
+            Qt::Edges edges;
+            switch (msg->wParam) {
+            case HTLEFT:
+                edges = Qt::LeftEdge;
+                break;
+            case HTRIGHT:
+                edges = Qt::RightEdge;
+                break;
+            case HTTOP:
+                edges = Qt::TopEdge;
+                break;
+            case HTBOTTOM:
+                edges = Qt::BottomEdge;
+                break;
+            case HTTOPLEFT:
+                edges = Qt::TopEdge | Qt::LeftEdge;
+                break;
+            case HTTOPRIGHT:
+                edges = Qt::TopEdge | Qt::RightEdge;
+                break;
+            case HTBOTTOMLEFT:
+                edges = Qt::BottomEdge | Qt::LeftEdge;
+                break;
+            case HTBOTTOMRIGHT:
+                edges = Qt::BottomEdge | Qt::RightEdge;
+                break;
+            default:
+                break;
+            }
+            if (windowHandle() != nullptr && (edges != Qt::Edges() || msg->wParam == HTCAPTION)) {
+                const bool started = edges != Qt::Edges() ? windowHandle()->startSystemResize(edges)
+                                                          : windowHandle()->startSystemMove();
+                if (!started) {
+                    finishRegionInteraction();
+                }
+                *result = 0;
                 return true;
             }
         }
@@ -388,6 +513,9 @@ bool ScreenRecordingAreaWindow::nativeEvent(const QByteArray& eventType, void* m
 
 void ScreenRecordingAreaWindow::applyNativePassThrough(bool enabled) {
 #if defined(Q_OS_WIN) || defined(_WIN32)
+    if (QGuiApplication::platformName() != QStringLiteral("windows")) {
+        return;
+    }
     const HWND handle = reinterpret_cast<HWND>(winId());
     if (handle == nullptr) {
         return;
@@ -422,13 +550,6 @@ void ScreenRecordingAreaWindow::paintEvent(QPaintEvent* event) {
         (m_inputMode == InputMode::RegionEditing && regionEditingEnabled())) {
         // Windows passes mouse input through zero-alpha pixels in layered windows.
         painter.fillRect(m_selectionRect, QColor(0, 0, 0, 2));
-    } else if (regionEditingEnabled()) {
-        // Keep a usable resize target while the center remains transparent to input.
-        const QRectF interior = m_selectionRect.adjusted(kResizeHitWidth, kResizeHitWidth,
-                                                         -kResizeHitWidth, -kResizeHitWidth);
-        painter.setClipRegion(QRegion(rect()) - QRegion(interior.toAlignedRect()));
-        painter.fillRect(m_selectionRect, QColor(0, 0, 0, 2));
-        painter.setClipping(false);
     }
     painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
     painter.setRenderHint(QPainter::Antialiasing, false);

--- a/snow_shot/src/presentation/recording/screenrecordingcontroller.cpp
+++ b/snow_shot/src/presentation/recording/screenrecordingcontroller.cpp
@@ -271,6 +271,19 @@ void copyFileToClipboard(const QString& filePath) {
 }
 } // namespace
 
+namespace {
+// UI resources and connection contexts exist only for an open selection. Backend
+// finalization belongs to the controller and can finish after this object is retired.
+struct RecordingUiSession final : QObject {
+    explicit RecordingUiSession(QObject* parent) : QObject(parent) {}
+    std::unique_ptr<ScreenRecordingAreaWindow> area = std::make_unique<ScreenRecordingAreaWindow>();
+    std::unique_ptr<ScreenRecordingToolbarWindow> toolbar =
+        std::make_unique<ScreenRecordingToolbarWindow>();
+    std::unique_ptr<QObject> connections = std::make_unique<QObject>();
+    std::unique_ptr<ScreenRecordingShortcutController> shortcuts;
+};
+} // namespace
+
 struct ScreenRecordingController::Impl {
     explicit Impl(ScreenRecordingController& owner) : owner(owner) {
         const snow_shot::storage::RecordingSettings settings;
@@ -309,38 +322,16 @@ struct ScreenRecordingController::Impl {
             snow_capture_recording_session_destroy(recordingSession);
         }
         recordingSession = nullptr;
-        restoreToolbarCaptureVisibility();
-        if (toolbarWindow != nullptr) {
-            toolbarWindow->hide();
-            toolbarWindow->deleteLater();
-        }
-        if (areaWindow != nullptr) {
-            areaWindow->hide();
-            areaWindow->deleteLater();
-        }
+        destroyUi();
     }
 
     void open(const QRect& region) {
-        if (!region.isValid() || region.isEmpty() || busy ||
+        if (region.width() < 2 || region.height() < 2 || busy ||
             state != ScreenshotToolPalette::RecordingState::Idle) {
             return;
         }
         cancelPendingStart();
-        // Closing hides these persistent windows; reopening must not orphan
-        // another toolbar and its connections to this controller.
-        if (areaWindow != nullptr && toolbarWindow != nullptr) {
-            if (!isOpen()) {
-                // Window lifetime spans sessions, but annotations and transient
-                // editing state belong only to the session that created them.
-                auto* palette = toolbarWindow->palette();
-                palette->clearActiveTool();
-                auto* canvas = areaWindow->canvas();
-                static_cast<void>(canvas->resetEditingState());
-                static_cast<void>(canvas->clearDocument());
-                areaWindow->setInputMode(palette->recordingExportSettingsVisible()
-                                             ? ScreenRecordingAreaWindow::InputMode::RegionEditing
-                                             : ScreenRecordingAreaWindow::InputMode::PassThrough);
-            }
+        if (uiSession != nullptr) {
             physicalRegion = region;
             updateCaptureRegion();
             areaWindow->setPhysicalRegion(region);
@@ -353,8 +344,9 @@ struct ScreenRecordingController::Impl {
 
         physicalRegion = region;
         updateCaptureRegion();
-        areaWindow = new ScreenRecordingAreaWindow();
-        toolbarWindow = new ScreenRecordingToolbarWindow();
+        uiSession = new RecordingUiSession(&owner);
+        areaWindow = uiSession->area.get();
+        toolbarWindow = uiSession->toolbar.get();
         // Keep the toolbar above the area even when drawing or resizing activates the area.
         toolbarWindow->setTransientOwnerWindow(areaWindow);
         areaWindow->setAttribute(Qt::WA_DeleteOnClose, false);
@@ -362,8 +354,8 @@ struct ScreenRecordingController::Impl {
         areaWindow->setPhysicalRegion(region);
         toolbarWindow->placeForPhysicalRegion(region);
         connectToolbar();
-        shortcutController = std::make_unique<ScreenRecordingShortcutController>(
-            *areaWindow, *toolbarWindow, &owner);
+        uiSession->shortcuts =
+            std::make_unique<ScreenRecordingShortcutController>(*areaWindow, *toolbarWindow);
 
         state = ScreenshotToolPalette::RecordingState::Idle;
         durationMilliseconds = 0;
@@ -386,8 +378,8 @@ struct ScreenRecordingController::Impl {
             return;
         }
         connectDrawingToolbar(*palette);
-        QObject::connect(areaWindow, &ScreenRecordingAreaWindow::physicalRegionChanged, &owner,
-                         [this](const QRect& region) {
+        QObject::connect(areaWindow, &ScreenRecordingAreaWindow::physicalRegionChanged,
+                         uiSession->connections.get(), [this](const QRect& region) {
                              if (state != ScreenshotToolPalette::RecordingState::Idle || busy) {
                                  return;
                              }
@@ -395,56 +387,69 @@ struct ScreenRecordingController::Impl {
                              updateCaptureRegion();
                              toolbarWindow->placeForPhysicalRegion(region);
                          });
+        QObject::connect(areaWindow, &ScreenRecordingAreaWindow::regionInteractionStarted,
+                         uiSession->connections.get(),
+                         [this]() { toolbarWindow->beginRegionInteraction(); });
+        QObject::connect(areaWindow, &ScreenRecordingAreaWindow::regionInteractionFinished,
+                         uiSession->connections.get(), [this]() {
+                             if (areaWindow->isVisible()) {
+                                 toolbarWindow->endRegionInteraction(areaWindow->physicalRegion());
+                             }
+                         });
+        QObject::connect(areaWindow, &ScreenRecordingAreaWindow::closeRequested,
+                         uiSession->connections.get(), [this]() { close(); });
+        QObject::connect(toolbarWindow, &ScreenRecordingToolbarWindow::closeRequested,
+                         uiSession->connections.get(), [this]() { close(); });
         if (palette->recordingExportSettingsVisible()) {
             areaWindow->setInputMode(ScreenRecordingAreaWindow::InputMode::RegionEditing);
         }
-        QObject::connect(palette, &ScreenshotToolPalette::recordingStartRequested, &owner,
-                         [this]() { start(); });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingStopRequested, &owner,
-                         [this]() { stop(false, false); });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingPauseRequested, &owner,
-                         [this]() { pause(); });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingResumeRequested, &owner,
-                         [this]() { resume(); });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingMicrophoneToggled, &owner,
-                         [this](bool enabled) {
+        QObject::connect(palette, &ScreenshotToolPalette::recordingStartRequested,
+                         uiSession->connections.get(), [this]() { start(); });
+        QObject::connect(palette, &ScreenshotToolPalette::recordingStopRequested,
+                         uiSession->connections.get(), [this]() { stop(false); });
+        QObject::connect(palette, &ScreenshotToolPalette::recordingPauseRequested,
+                         uiSession->connections.get(), [this]() { pause(); });
+        QObject::connect(palette, &ScreenshotToolPalette::recordingResumeRequested,
+                         uiSession->connections.get(), [this]() { resume(); });
+        QObject::connect(palette, &ScreenshotToolPalette::recordingMicrophoneToggled,
+                         uiSession->connections.get(), [this](bool enabled) {
                              microphoneEnabled = enabled;
                              snow_shot::storage::RecordingSettings().setMicrophoneEnabled(enabled);
                          });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingSystemAudioToggled, &owner,
-                         [this](bool enabled) {
+        QObject::connect(palette, &ScreenshotToolPalette::recordingSystemAudioToggled,
+                         uiSession->connections.get(), [this](bool enabled) {
                              systemAudioEnabled = enabled;
                              snow_shot::storage::RecordingSettings().setSystemAudioEnabled(enabled);
                          });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingOpenFolderRequested, &owner,
-                         [this]() { openFolder(); });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingCloseRequested, &owner,
-                         [this]() { close(); });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingCopyRequested, &owner,
-                         [this]() { stop(true, false); });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingOutputFormatChanged, &owner,
-                         [this](const QString& format) {
+        QObject::connect(palette, &ScreenshotToolPalette::recordingOpenFolderRequested,
+                         uiSession->connections.get(), [this]() { openFolder(); });
+        QObject::connect(palette, &ScreenshotToolPalette::recordingCloseRequested,
+                         uiSession->connections.get(), [this]() { close(); });
+        QObject::connect(palette, &ScreenshotToolPalette::recordingCopyRequested,
+                         uiSession->connections.get(), [this]() { stop(true); });
+        QObject::connect(palette, &ScreenshotToolPalette::recordingOutputFormatChanged,
+                         uiSession->connections.get(), [this](const QString& format) {
                              outputFormat = format;
                              snow_shot::storage::RecordingSettings().setOutputFormat(format);
                          });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingMouseTrailColorChanged, &owner,
-                         [this](const QColor& color) {
+        QObject::connect(palette, &ScreenshotToolPalette::recordingMouseTrailColorChanged,
+                         uiSession->connections.get(), [this](const QColor& color) {
                              mouseTrailColor = color;
                              snow_shot::storage::RecordingSettings().setMouseTrailColor(color);
                          });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingMouseClickColorChanged, &owner,
-                         [this](const QColor& color) {
+        QObject::connect(palette, &ScreenshotToolPalette::recordingMouseClickColorChanged,
+                         uiSession->connections.get(), [this](const QColor& color) {
                              mouseClickColor = color;
                              snow_shot::storage::RecordingSettings().setMouseClickColor(color);
                          });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingKeyboardVisibleChanged, &owner,
-                         [this](bool visible) {
+        QObject::connect(palette, &ScreenshotToolPalette::recordingKeyboardVisibleChanged,
+                         uiSession->connections.get(), [this](bool visible) {
                              showKeyboard = visible;
                              snow_shot::storage::RecordingSettings().setShowKeyboard(visible);
                              syncUi();
                          });
-        QObject::connect(palette, &ScreenshotToolPalette::recordingCursorVisibleChanged, &owner,
-                         [this](bool visible) {
+        QObject::connect(palette, &ScreenshotToolPalette::recordingCursorVisibleChanged,
+                         uiSession->connections.get(), [this](bool visible) {
                              showCursor = visible;
                              snow_shot::storage::RecordingSettings().setShowCursor(visible);
                          });
@@ -459,80 +464,98 @@ struct ScreenRecordingController::Impl {
             canvas->setCanvasTool(tool);
             areaWindow->setInputMode(ScreenRecordingAreaWindow::InputMode::Drawing);
         };
-        snow_shot::presentation::recording::connectScreenRecordingSelection(palette, *areaWindow,
-                                                                            owner);
-        QObject::connect(&palette, &ScreenshotToolPalette::shapeRequested, &owner,
+        snow_shot::presentation::recording::connectScreenRecordingSelection(
+            palette, *areaWindow, *uiSession->connections);
+        QObject::connect(&palette, &ScreenshotToolPalette::shapeRequested,
+                         uiSession->connections.get(),
                          [activate]() { activate(SnowCanvasTool::Shape); });
-        QObject::connect(&palette, &ScreenshotToolPalette::arrowRequested, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::arrowRequested,
+                         uiSession->connections.get(),
                          [activate]() { activate(SnowCanvasTool::Arrow); });
-        QObject::connect(&palette, &ScreenshotToolPalette::lineRequested, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::lineRequested,
+                         uiSession->connections.get(),
                          [activate]() { activate(SnowCanvasTool::Line); });
-        QObject::connect(&palette, &ScreenshotToolPalette::freeDrawRequested, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::freeDrawRequested,
+                         uiSession->connections.get(),
                          [activate]() { activate(SnowCanvasTool::FreeDraw); });
-        QObject::connect(&palette, &ScreenshotToolPalette::spotlightRequested, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::spotlightRequested,
+                         uiSession->connections.get(),
                          [activate]() { activate(SnowCanvasTool::Spotlight); });
-        QObject::connect(&palette, &ScreenshotToolPalette::eraserRequested, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::eraserRequested,
+                         uiSession->connections.get(),
                          [activate]() { activate(SnowCanvasTool::Eraser); });
-        QObject::connect(&palette, &ScreenshotToolPalette::watermarkRequested, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::watermarkRequested,
+                         uiSession->connections.get(),
                          [activate]() { activate(SnowCanvasTool::Watermark); });
-        QObject::connect(&palette, &ScreenshotToolPalette::textRequested, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::textRequested,
+                         uiSession->connections.get(),
                          [activate]() { activate(SnowCanvasTool::Text); });
-        QObject::connect(&palette, &ScreenshotToolPalette::serialNumberRequested, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::serialNumberRequested,
+                         uiSession->connections.get(),
                          [activate]() { activate(SnowCanvasTool::SerialNumber); });
-        QObject::connect(&palette, &ScreenshotToolPalette::undoRequested, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::undoRequested,
+                         uiSession->connections.get(),
                          [canvas]() { static_cast<void>(canvas->undo()); });
-        QObject::connect(&palette, &ScreenshotToolPalette::redoRequested, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::redoRequested,
+                         uiSession->connections.get(),
                          [canvas]() { static_cast<void>(canvas->redo()); });
-        QObject::connect(&palette, &ScreenshotToolPalette::shapeStyleChanged, &owner,
-                         [canvas, &palette](const SnowCanvasShapeStyle& style, quint32 properties,
-                                            SnowCanvasShapeKind kind) {
-                             canvas->setCanvasShapeStylePatch(style, properties, kind);
-                             static_cast<void>(
-                                 snow_shot::presentation::persistScreenshotCanvasToolStyles(
-                                     palette.creationStyleDefaults()));
-                         });
-        QObject::connect(&palette, &ScreenshotToolPalette::textStyleChanged, &owner,
-                         [canvas, &palette](const SnowCanvasTextStyle& style) {
-                             static_cast<void>(canvas->setCanvasTextStyle(style));
-                             static_cast<void>(
-                                 snow_shot::presentation::persistScreenshotCanvasToolStyles(
-                                     palette.creationStyleDefaults()));
-                         });
-        QObject::connect(&palette, &ScreenshotToolPalette::serialNumberStyleChanged, &owner,
+        QObject::connect(
+            &palette, &ScreenshotToolPalette::shapeStyleChanged, uiSession->connections.get(),
+            [canvas, &palette](const SnowCanvasShapeStyle& style, quint32 properties,
+                               SnowCanvasShapeKind kind) {
+                canvas->setCanvasShapeStylePatch(style, properties, kind);
+                static_cast<void>(snow_shot::presentation::persistScreenshotCanvasToolStyles(
+                    palette.creationStyleDefaults()));
+            });
+        QObject::connect(
+            &palette, &ScreenshotToolPalette::textStyleChanged, uiSession->connections.get(),
+            [canvas, &palette](const SnowCanvasTextStyle& style) {
+                static_cast<void>(canvas->setCanvasTextStyle(style));
+                static_cast<void>(snow_shot::presentation::persistScreenshotCanvasToolStyles(
+                    palette.creationStyleDefaults()));
+            });
+        QObject::connect(&palette, &ScreenshotToolPalette::serialNumberStyleChanged,
+                         uiSession->connections.get(),
                          [canvas, &palette](const SnowCanvasSerialNumberStyle& style) {
                              static_cast<void>(canvas->setCanvasSerialNumberStyle(style));
                              static_cast<void>(
                                  snow_shot::presentation::persistScreenshotCanvasToolStyles(
                                      palette.creationStyleDefaults()));
                          });
-        QObject::connect(&palette, &ScreenshotToolPalette::watermarkConfigChanged, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::watermarkConfigChanged,
+                         uiSession->connections.get(),
                          [canvas](const SnowCanvasWatermarkConfig& config) {
                              static_cast<void>(canvas->setCanvasWatermarkConfig(config));
                          });
-        QObject::connect(&palette, &ScreenshotToolPalette::watermarkPreviewChanged, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::watermarkPreviewChanged,
+                         uiSession->connections.get(),
                          [canvas](const SnowCanvasWatermarkConfig& config) {
                              canvas->previewCanvasWatermarkConfig(config);
                          });
-        QObject::connect(&palette, &ScreenshotToolPalette::spotlightConfigChanged, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::spotlightConfigChanged,
+                         uiSession->connections.get(),
                          [canvas](const SnowCanvasSpotlightConfig& config) {
                              static_cast<void>(canvas->setCanvasSpotlightConfig(config));
                          });
-        QObject::connect(&palette, &ScreenshotToolPalette::spotlightPreviewChanged, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::spotlightPreviewChanged,
+                         uiSession->connections.get(),
                          [canvas](const SnowCanvasSpotlightConfig& config) {
                              canvas->previewCanvasSpotlightConfig(config);
                          });
-        QObject::connect(&palette, &ScreenshotToolPalette::textStylePopupInteractionBegan, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::textStylePopupInteractionBegan,
+                         uiSession->connections.get(),
                          [canvas]() { canvas->beginTextStylePopupInteraction(); });
-        QObject::connect(&palette, &ScreenshotToolPalette::textStylePopupInteractionEnded, &owner,
+        QObject::connect(&palette, &ScreenshotToolPalette::textStylePopupInteractionEnded,
+                         uiSession->connections.get(),
                          [canvas, this]() { canvas->endTextStylePopupInteraction(toolbarWindow); });
         QObject::connect(areaWindow, &ScreenRecordingAreaWindow::drawingDeactivationRequested,
-                         &owner, [this, &palette]() {
+                         uiSession->connections.get(), [this, &palette]() {
                              palette.clearActiveTool();
                              areaWindow->setInputMode(
                                  ScreenRecordingAreaWindow::InputMode::PassThrough);
                          });
-        QObject::connect(areaWindow, &ScreenRecordingAreaWindow::drawingWheelRequested, &owner,
-                         [canvas, &palette](int direction) {
+        QObject::connect(areaWindow, &ScreenRecordingAreaWindow::drawingWheelRequested,
+                         uiSession->connections.get(), [canvas, &palette](int direction) {
                              switch (canvas->canvasTool()) {
                              case SnowCanvasTool::Shape:
                              case SnowCanvasTool::Arrow:
@@ -716,14 +739,11 @@ struct ScreenRecordingController::Impl {
         syncUi();
     }
 
-    void stop(bool copyToClipboard, bool closeAfter) {
+    void stop(bool copyToClipboard) {
         if (busy) {
             return;
         }
         if (state == ScreenshotToolPalette::RecordingState::Idle || recordingSession == nullptr) {
-            if (closeAfter) {
-                hideWindows();
-            }
             return;
         }
 
@@ -737,7 +757,6 @@ struct ScreenRecordingController::Impl {
             return std::make_pair(ok, ok ? QString() : captureError());
         });
         pendingCopyToClipboard = copyToClipboard;
-        pendingCloseAfter = closeAfter;
         finalizationPollTimer.start();
     }
 
@@ -769,9 +788,6 @@ struct ScreenRecordingController::Impl {
         if (pendingCopyToClipboard) {
             copyFileToClipboard(pendingOutputPath);
         }
-        if (pendingCloseAfter) {
-            hideWindows();
-        }
     }
 
     bool pollSessionLiveness() {
@@ -784,7 +800,7 @@ struct ScreenRecordingController::Impl {
             nativeState != SNOW_CAPTURE_RECORDING_STATE_STOPPED) {
             return false;
         }
-        stop(false, false);
+        stop(false);
         return true;
     }
 
@@ -795,22 +811,27 @@ struct ScreenRecordingController::Impl {
     }
 
     void close() {
-        if (state == ScreenshotToolPalette::RecordingState::Idle) {
-            hideWindows();
-            return;
-        }
-        stop(false, true);
+        stop(false);
+        destroyUi();
     }
 
-    void hideWindows() {
+    void destroyUi() {
         cancelPendingStart();
+        if (uiSession == nullptr) {
+            return;
+        }
+        auto* retiring = uiSession;
+        uiSession = nullptr;
+        areaWindow = nullptr;
+        toolbarWindow = nullptr;
+        // Disconnect before hiding: hide/focus events can emit canvas and geometry signals.
+        retiring->connections.reset();
+        retiring->shortcuts.reset();
+        retiring->toolbar->hide();
+        retiring->area->hide();
         restoreToolbarCaptureVisibility();
-        if (toolbarWindow != nullptr) {
-            toolbarWindow->hide();
-        }
-        if (areaWindow != nullptr) {
-            areaWindow->hide();
-        }
+        // Close can originate in a toolbar button's event handler.
+        retiring->deleteLater();
     }
 
     void excludeToolbarFromCapture() {
@@ -858,6 +879,7 @@ struct ScreenRecordingController::Impl {
     }
 
     ScreenRecordingController& owner;
+    RecordingUiSession* uiSession = nullptr;
     ScreenRecordingAreaWindow* areaWindow = nullptr;
     ScreenRecordingToolbarWindow* toolbarWindow = nullptr;
     SnowCaptureRecordingSession* recordingSession = nullptr;
@@ -881,7 +903,6 @@ struct ScreenRecordingController::Impl {
     QColor sessionMouseClickColor{0, 0, 0, 0};
     bool sessionShowCursor = true;
     bool busy = false;
-    std::unique_ptr<ScreenRecordingShortcutController> shortcutController;
     void report(const QString& event, QtMsgType level = QtInfoMsg) const {
         snow_shot::diagnostics::logEvent(QStringLiteral("snow_shot.recording"), event,
                                          {{QStringLiteral("operation"), operation},
@@ -895,7 +916,6 @@ struct ScreenRecordingController::Impl {
     bool startScheduled = false;
     quint64 startGeneration = 0;
     bool pendingCopyToClipboard = false;
-    bool pendingCloseAfter = false;
     snow_shot::presentation::WindowCaptureExclusion captureExclusion{
 #if defined(Q_OS_WIN) || defined(_WIN32)
         snow_shot::platform::windows::setWindowExcludedFromCapture
@@ -925,5 +945,5 @@ void ScreenRecordingController::startRecording() {
 }
 
 void ScreenRecordingController::stopRecordingAndCopy() {
-    m_impl->stop(true, false);
+    m_impl->stop(true);
 }

--- a/snow_shot/src/presentation/recording/screenrecordinggeometry.cpp
+++ b/snow_shot/src/presentation/recording/screenrecordinggeometry.cpp
@@ -15,8 +15,23 @@ qreal validScale(qreal scale) {
 } // namespace
 
 namespace snow_shot::presentation::recording {
+ScreenRecordingObservedGeometry screenRecordingObservedGeometry(const QRect& physicalClientRect,
+                                                                qreal physicalScale,
+                                                                const QMargins& physicalInsets) {
+    const QRect selected = physicalClientRect.marginsRemoved(physicalInsets);
+    if (selected.width() < 2 || selected.height() < 2) {
+        return {};
+    }
+    const qreal scale = validScale(physicalScale);
+    const QRectF selection(physicalInsets.left() / scale, physicalInsets.top() / scale,
+                           selected.width() / scale, selected.height() / scale);
+    const qreal inset = screenRecordingPhysicalFrameInset / scale;
+    return {selected, selection.adjusted(-inset, -inset, inset, inset), selection,
+            kPhysicalBorderPadding / scale};
+}
+
 ScreenRecordingAreaFrameGeometry screenRecordingAreaFrameGeometry(const QRectF& logicalRegion,
-                                                                qreal physicalScale) {
+                                                                  qreal physicalScale) {
     if (!logicalRegion.isValid() || logicalRegion.isEmpty()) {
         return {};
     }
@@ -33,11 +48,7 @@ ScreenRecordingAreaFrameGeometry screenRecordingAreaFrameGeometry(const QRectF& 
         selectionRect.adjusted(-frameInset, -frameInset, frameInset, frameInset);
 
     return ScreenRecordingAreaFrameGeometry{
-        windowGeometry,
-        frameRect,
-        selectionRect,
-        borderWidth,
-        paddingWidth,
+        windowGeometry, frameRect, selectionRect, borderWidth, paddingWidth,
     };
 }
 
@@ -68,7 +79,7 @@ ScreenRecordingAreaBorderGeometry screenRecordingAreaBorderGeometry(const QRectF
 }
 
 QRect screenRecordingCompatibleCaptureRegion(const QRect& selectedPhysicalRegion,
-                                            const QRect& physicalBounds) {
+                                             const QRect& physicalBounds) {
     if (!selectedPhysicalRegion.isValid() || selectedPhysicalRegion.isEmpty()) {
         return {};
     }
@@ -114,8 +125,7 @@ QSize screenRecordingOrientedMaximumSize(const QSize& maximumSize, const QSize& 
     const bool maximumIsPortrait = maximumSize.height() > maximumSize.width();
     const bool captureIsLandscape = captureSize.width() > captureSize.height();
     const bool captureIsPortrait = captureSize.height() > captureSize.width();
-    if ((maximumIsLandscape && captureIsPortrait) ||
-        (maximumIsPortrait && captureIsLandscape)) {
+    if ((maximumIsLandscape && captureIsPortrait) || (maximumIsPortrait && captureIsLandscape)) {
         return maximumSize.transposed();
     }
     return maximumSize;

--- a/snow_shot/src/presentation/recording/screenrecordinggeometry.h
+++ b/snow_shot/src/presentation/recording/screenrecordinggeometry.h
@@ -2,6 +2,7 @@
 #define SNOW_SHOT_PRESENTATION_RECORDING_SCREENRECORDINGGEOMETRY_H
 
 #include <QRect>
+#include <QMargins>
 #include <QRectF>
 #include <QSize>
 #include <QString>
@@ -23,6 +24,20 @@ struct ScreenRecordingAreaBorderGeometry {
     QRectF right;
 };
 
+inline constexpr int screenRecordingPhysicalFrameInset = 3;
+
+struct ScreenRecordingObservedGeometry {
+    QRect physicalRegion;
+    QRectF frameRect;
+    QRectF selectionRect;
+    qreal paddingWidth = 0.0;
+};
+
+// The native client rectangle already uses virtual-desktop physical pixels.
+[[nodiscard]] ScreenRecordingObservedGeometry
+screenRecordingObservedGeometry(const QRect& physicalClientRect, qreal physicalScale,
+                                const QMargins& physicalInsets = QMargins(3, 3, 3, 3));
+
 [[nodiscard]] ScreenRecordingAreaFrameGeometry
 screenRecordingAreaFrameGeometry(const QRectF& logicalRegion, qreal physicalScale);
 
@@ -31,12 +46,12 @@ screenRecordingAreaBorderGeometry(const QRectF& frameRect, const QRectF& selecti
                                   qreal paddingWidth);
 
 [[nodiscard]] QRect screenRecordingCompatibleCaptureRegion(const QRect& selectedPhysicalRegion,
-                                                          const QRect& physicalBounds);
+                                                           const QRect& physicalBounds);
 
 [[nodiscard]] QSize screenRecordingMaximumSizeForClarity(const QString& clarity);
 
 [[nodiscard]] QSize screenRecordingOrientedMaximumSize(const QSize& maximumSize,
-                                                      const QSize& captureSize);
+                                                       const QSize& captureSize);
 } // namespace snow_shot::presentation::recording
 
 #endif // SNOW_SHOT_PRESENTATION_RECORDING_SCREENRECORDINGGEOMETRY_H

--- a/snow_shot/src/presentation/recording/screenrecordingselection.h
+++ b/snow_shot/src/presentation/recording/screenrecordingselection.h
@@ -10,15 +10,17 @@ namespace snow_shot::presentation::recording {
 inline void connectScreenRecordingSelection(ScreenshotToolPalette& palette,
                                             ScreenRecordingAreaWindow& area, QObject& context) {
     auto* canvas = area.canvas();
-    QObject::connect(&palette, &ScreenshotToolPalette::selectRequested, &context,
-                     [&palette, &area, canvas]() {
-                         if (palette.activeTool() == ScreenshotToolPalette::Tool::Select) {
-                             canvas->setCanvasTool(SnowCanvasTool::Select);
-                             area.setInputMode(ScreenRecordingAreaWindow::InputMode::Drawing);
-                         } else {
-                             area.setInputMode(ScreenRecordingAreaWindow::InputMode::PassThrough);
-                         }
-                     });
+    QObject::connect(
+        &palette, &ScreenshotToolPalette::selectRequested, &context, [&palette, &area, canvas]() {
+            if (palette.activeTool() == ScreenshotToolPalette::Tool::Select) {
+                canvas->setCanvasTool(SnowCanvasTool::Select);
+                area.setInputMode(ScreenRecordingAreaWindow::InputMode::Drawing);
+            } else {
+                area.setInputMode(palette.recordingExportSettingsVisible()
+                                      ? ScreenRecordingAreaWindow::InputMode::RegionEditing
+                                      : ScreenRecordingAreaWindow::InputMode::PassThrough);
+            }
+        });
     QObject::connect(&palette, &ScreenshotToolPalette::recordingExportSettingsVisibleChanged,
                      &context, [&area](bool visible) {
                          area.setInputMode(visible

--- a/snow_shot/src/presentation/recording/screenrecordingtoolbarwindow.cpp
+++ b/snow_shot/src/presentation/recording/screenrecordingtoolbarwindow.cpp
@@ -8,6 +8,9 @@
 #include "screenrecordinggeometry.h"
 
 #include <QScreen>
+#include <QCloseEvent>
+#include "widgets/color_picker.h"
+#include "widgets/select.h"
 #include <QScopedValueRollback>
 
 namespace {
@@ -50,7 +53,7 @@ ScreenRecordingToolbarWindow::ScreenRecordingToolbarWindow(QWidget* parent)
     // Secondary rows can grow without changing the fixed native frame or the
     // main-row anchor. Observe the committed host content, including those cases.
     connect(paletteHost(), &ScreenshotToolPaletteHost::visibleContentChanged, this, [this]() {
-        if (!m_manuallyDragged) {
+        if (!m_manuallyDragged && !m_regionInteractionActive) {
             placeForPhysicalRegion(m_physicalRegion);
         }
     });
@@ -59,6 +62,10 @@ ScreenRecordingToolbarWindow::ScreenRecordingToolbarWindow(QWidget* parent)
 }
 
 void ScreenRecordingToolbarWindow::showAndActivate() {
+    if (m_regionInteractionActive) {
+        return;
+    }
+    prepareForDisplay();
     show();
     raise();
     activateWindow();
@@ -66,7 +73,8 @@ void ScreenRecordingToolbarWindow::showAndActivate() {
 }
 
 void ScreenRecordingToolbarWindow::placeForPhysicalRegion(const QRect& physicalRegion) {
-    if (m_placing || !physicalRegion.isValid() || physicalRegion.isEmpty()) {
+    if (m_regionInteractionActive || m_placing || !physicalRegion.isValid() ||
+        physicalRegion.isEmpty()) {
         return;
     }
     QScreen* screen = ScreenshotGeometryMapper::screenForPhysicalRect(physicalRegion);
@@ -99,6 +107,43 @@ void ScreenRecordingToolbarWindow::placeForPhysicalRegion(const QRect& physicalR
             QPoint(anchorRegion.left() + anchorRegion.width(), anchorRegion.top()),
             toolbarGeometry.bottom, toolbarGeometry.top, logicalBounds, kToolbarGap);
     setStyleToolbarAboveMain(placement.usesTopRightPlacement);
-    resetPhysicalSizeInvariant();
     moveContentTo(placement.contentPosition);
+    // As in screenshot toolbar presentation, reconcile the actual native frame
+    // after moving across displays before it can paint the prepared content.
+    prepareForDisplay();
+}
+
+void ScreenRecordingToolbarWindow::beginRegionInteraction() {
+    if (m_regionInteractionActive) {
+        return;
+    }
+    m_regionInteractionActive = true;
+    for (auto* picker : palette()->findChildren<adqt::widgets::AdColorPicker*>()) {
+        picker->setPopupVisible(false);
+    }
+    for (auto* select : palette()->findChildren<adqt::widgets::AdSelect*>()) {
+        select->setPopupVisible(false);
+    }
+    hide();
+    for (QWidget* child : findChildren<QWidget*>()) {
+        if (child->isWindow()) {
+            child->hide();
+        }
+    }
+}
+
+void ScreenRecordingToolbarWindow::endRegionInteraction(const QRect& physicalRegion) {
+    if (!m_regionInteractionActive) {
+        return;
+    }
+    m_regionInteractionActive = false;
+    placeForPhysicalRegion(physicalRegion);
+    prepareForDisplay();
+    show();
+    raise();
+}
+
+void ScreenRecordingToolbarWindow::closeEvent(QCloseEvent* event) {
+    event->ignore();
+    emit closeRequested();
 }

--- a/snow_shot/src/presentation/tools/screenshotfloatingtoolpalettewindow.cpp
+++ b/snow_shot/src/presentation/tools/screenshotfloatingtoolpalettewindow.cpp
@@ -113,7 +113,10 @@ ScreenshotFloatingToolPaletteWindow::ScreenshotFloatingToolPaletteWindow(
                     }
                     if (updatesWereEnabled) {
                         setUpdatesEnabled(true);
-                        update();
+                        // Complete the presentation transaction now. An update()
+                        // can coalesce with dirty state left by the hidden DPI
+                        // transition, leaving the old backing-store pixels on screen.
+                        repaint();
                     }
                 });
                 emit dpiScaleCommitCompleted();

--- a/snow_shot/src/presentation/tools/screenshottoolpalette.cpp
+++ b/snow_shot/src/presentation/tools/screenshottoolpalette.cpp
@@ -3254,7 +3254,7 @@ void ScreenshotToolPalette::createMainToolbar(const Options& options) {
             QStringLiteral("screenRecordingExportSettings"));
         panelLayout->addWidget(m_recordExportSettingsButton);
         connect(m_recordExportSettingsButton, &adqt::widgets::AdButton::clicked, this,
-                [this]() { setRecordingExportSettingsVisible(!m_recordExportSettingsVisible); });
+                [this]() { setRecordingExportSettingsVisible(true); });
     }
 
     const bool hasEditingTools = addMainToolButtons(options, panelLayout);
@@ -3505,8 +3505,7 @@ bool ScreenshotToolPalette::activateToolFromToolbar(Tool tool, bool toggleVisibl
         : requestedButton != nullptr ? m_activeToolButton == requestedButton
                                      : m_activeTool.has_value() && *m_activeTool == tool;
     if (alreadyActive && m_options.recordingDrawingMode) {
-        clearActiveTool();
-        emit selectRequested();
+        setRecordingExportSettingsVisible(true);
         return true;
     }
     const Tool requestedTool = alreadyActive && tool != Tool::Select ? Tool::Select : tool;

--- a/snow_shot/tests/screen_recording_area_window_tests.cpp
+++ b/snow_shot/tests/screen_recording_area_window_tests.cpp
@@ -12,9 +12,34 @@
 #include <QPainter>
 #include <QScreen>
 #include <QWheelEvent>
+#include <QTimer>
+#include <QDebug>
+#include "snow_draw_engine_qt/snow_canvas_runtime.h"
 
 #include <cstdlib>
 #include <iostream>
+#if defined(Q_OS_WIN) || defined(_WIN32)
+#include <qt_windows.h>
+#endif
+
+class ScreenRecordingAreaWindowTestAccess {
+  public:
+    static bool editable(const ScreenRecordingAreaWindow& area) {
+        return area.regionEditingEnabled();
+    }
+    static Qt::Edges edges(const ScreenRecordingAreaWindow& area, QPointF position) {
+        return area.resizeEdgesAt(position);
+    }
+    static void begin(ScreenRecordingAreaWindow& area) {
+        area.beginRegionInteraction();
+    }
+    static void finish(ScreenRecordingAreaWindow& area) {
+        area.finishRegionInteraction();
+    }
+    static QByteArray history(const ScreenRecordingAreaWindow& area) {
+        return area.m_canvasRuntime->serializeDocumentHistory();
+    }
+};
 
 namespace {
 void require(bool condition, const char* message) {
@@ -97,9 +122,9 @@ void inputModesOwnOnlyDrawingInputAndRestoreRequestedState() {
     SnowCanvasWidget* canvas = area.canvas();
     require(canvas != nullptr &&
                 area.inputMode() == ScreenRecordingAreaWindow::InputMode::PassThrough &&
-                !area.testAttribute(Qt::WA_TransparentForMouseEvents) &&
+                area.testAttribute(Qt::WA_TransparentForMouseEvents) &&
                 !canvas->interactionEnabled(),
-            "idle pass-through should retain resize input without enabling drawing");
+            "pass-through must disable both movement and resizing");
 
     area.setInputMode(ScreenRecordingAreaWindow::InputMode::Drawing);
     require(!area.testAttribute(Qt::WA_TransparentForMouseEvents) && canvas->interactionEnabled(),
@@ -116,9 +141,9 @@ void inputModesOwnOnlyDrawingInputAndRestoreRequestedState() {
             "leaving a busy transition should restore drawing without recreating the window");
 
     area.setInputMode(ScreenRecordingAreaWindow::InputMode::PassThrough);
-    require(area.winId() == nativeId && !area.testAttribute(Qt::WA_TransparentForMouseEvents) &&
+    require(area.winId() == nativeId && area.testAttribute(Qt::WA_TransparentForMouseEvents) &&
                 !canvas->interactionEnabled(),
-            "deactivation should restore idle resize input on the existing native window");
+            "deactivation must release both movement and resize input");
     area.setRecordingState(ScreenshotToolPalette::RecordingState::Recording);
     require(area.testAttribute(Qt::WA_TransparentForMouseEvents),
             "recording pass-through should release the whole window's input");
@@ -241,216 +266,274 @@ void annotationsPersistAcrossStatesAndClearOnlyForANewRegion() {
             "opening a different recording region should clear the previous annotations once");
 }
 
-void sendRegionMouseEvent(QWidget& target, QEvent::Type type, const QPointF& global,
-                          Qt::MouseButton button, Qt::MouseButtons buttons) {
-    const QPointF local = global - QPointF(target.mapToGlobal(QPoint()));
-    QMouseEvent event(type, local, local, global, button, buttons, Qt::NoModifier);
-    QCoreApplication::sendEvent(&target, &event);
-}
-
-void dragRegion(ScreenRecordingAreaWindow& area, const QPointF& local, const QPointF& delta,
-                bool throughCanvas = false) {
-    QWidget& target = throughCanvas ? *static_cast<QWidget*>(area.canvas()) : area;
-    const QPointF start = QPointF(area.pos()) + local;
-    sendRegionMouseEvent(target, QEvent::MouseButtonPress, start, Qt::LeftButton, Qt::LeftButton);
-    sendRegionMouseEvent(target, QEvent::MouseMove, start + delta, Qt::NoButton, Qt::LeftButton);
-    sendRegionMouseEvent(target, QEvent::MouseButtonRelease, start + delta, Qt::LeftButton,
-                         Qt::NoButton);
-}
-
-void idleEdgesAndCornersResizePhysicalRegion() {
+void geometryEditingIsOneCapability() {
     ScreenRecordingAreaWindow area;
-    const QRect initial = testPhysicalRegion();
-    const qreal scale =
-        ScreenshotGeometryMapper::screenForPhysicalRect(initial)->devicePixelRatio();
-    const QPointF delta(13.0, 9.0);
-    const QPoint physicalDelta(qRound(delta.x() * scale), qRound(delta.y() * scale));
-    int changes = 0;
-    QObject::connect(
-        &area, &ScreenRecordingAreaWindow::physicalRegionChanged, &area, [&](const QRect& region) {
-            require(region == area.physicalRegion(),
-                    "region notification should contain the current physical selection");
-            ++changes;
-        });
+    area.setPhysicalRegion(testPhysicalRegion());
+    area.show();
     for (const auto mode : {ScreenRecordingAreaWindow::InputMode::PassThrough,
                             ScreenRecordingAreaWindow::InputMode::Drawing,
                             ScreenRecordingAreaWindow::InputMode::RegionEditing}) {
-        area.setInputMode(mode);
-        for (const Qt::Edges edges :
-             {Qt::Edges(Qt::LeftEdge), Qt::Edges(Qt::RightEdge), Qt::Edges(Qt::TopEdge),
-              Qt::Edges(Qt::BottomEdge), Qt::LeftEdge | Qt::TopEdge, Qt::RightEdge | Qt::TopEdge,
-              Qt::LeftEdge | Qt::BottomEdge, Qt::RightEdge | Qt::BottomEdge}) {
-            area.setPhysicalRegion(initial);
-            area.show();
-            QCoreApplication::processEvents();
-            const QRect selection = area.canvasGeometry();
-            QPointF start = selection.center();
-            QRect expected = initial;
-            if (edges.testFlag(Qt::LeftEdge)) {
-                start.setX(selection.left() + 1);
-                expected.setLeft(initial.left() + physicalDelta.x());
+        for (const auto state : {ScreenshotToolPalette::RecordingState::Idle,
+                                 ScreenshotToolPalette::RecordingState::Recording,
+                                 ScreenshotToolPalette::RecordingState::Paused}) {
+            for (const bool busy : {false, true}) {
+                area.setInputMode(mode);
+                area.setRecordingState(state);
+                area.setDrawingBlocked(busy);
+                const bool editable = mode == ScreenRecordingAreaWindow::InputMode::RegionEditing &&
+                                      state == ScreenshotToolPalette::RecordingState::Idle && !busy;
+                require(ScreenRecordingAreaWindowTestAccess::editable(area) == editable,
+                        "moving and resizing must share Export Settings idle eligibility");
+                require((ScreenRecordingAreaWindowTestAccess::edges(area, {1, 1}) != Qt::Edges()) ==
+                            editable,
+                        "resize hit targets must never outlive movement eligibility");
             }
-            if (edges.testFlag(Qt::RightEdge)) {
-                start.setX(selection.right() - 1);
-                expected.setRight(initial.right() + physicalDelta.x());
-            }
-            if (edges.testFlag(Qt::TopEdge)) {
-                start.setY(selection.top() + 1);
-                expected.setTop(initial.top() + physicalDelta.y());
-            }
-            if (edges.testFlag(Qt::BottomEdge)) {
-                start.setY(selection.bottom() - 1);
-                expected.setBottom(initial.bottom() + physicalDelta.y());
-            }
-            const int previousChanges = changes;
-            dragRegion(area, start, delta, true);
-            require(area.physicalRegion() == expected && changes == previousChanges + 1,
-                    "idle edges and corners should resize once using physical pixel deltas");
-            require(!area.canvas()->canvasHistoryState().canUndo,
-                    "resize gestures must not also create canvas annotations");
         }
     }
 }
 
-void exportSettingsMoveAndClampTheRegion() {
+void interactionBoundariesAreIdempotentAndCancelOnStateChanges() {
     ScreenRecordingAreaWindow area;
-    const QRect initial = testPhysicalRegion();
-    area.setPhysicalRegion(initial);
+    area.setPhysicalRegion(testPhysicalRegion());
     area.show();
-    QCoreApplication::processEvents();
-    dragRegion(area, area.canvasGeometry().center(), QPointF(20, 10), true);
-    require(area.physicalRegion() == initial,
-            "pass-through interior should not move the recording selection");
     area.setInputMode(ScreenRecordingAreaWindow::InputMode::RegionEditing);
-    const qreal scale =
-        ScreenshotGeometryMapper::screenForPhysicalRect(initial)->devicePixelRatio();
-    dragRegion(area, area.canvasGeometry().center(), QPointF(13, 9), true);
-    require(area.physicalRegion() == initial.translated(qRound(13 * scale), qRound(9 * scale)),
-            "export settings interior drag should move the region without changing its size");
-    require(!area.canvas()->interactionEnabled() && !area.canvas()->canvasHistoryState().canUndo,
-            "region movement should not enable or create drawing");
-    const QImage surface = renderWidget(area);
-    require(surface.pixelColor(area.canvasGeometry().center()).alpha() > 0,
-            "export settings should provide a native hit surface throughout the region");
-    const QRect bounds = ScreenshotGeometryMapper::physicalRectForScreen(
-        *ScreenshotGeometryMapper::screenForPhysicalRect(initial));
-    dragRegion(area, area.canvasGeometry().center(), QPointF(-10000, -10000), true);
-    require(area.physicalRegion().topLeft() == bounds.topLeft() &&
-                area.physicalRegion().size() == initial.size(),
-            "moving beyond the screen origin should clamp while preserving size");
-    dragRegion(area, area.canvasGeometry().center(), QPointF(10000, 10000), true);
-    require(area.physicalRegion().bottomRight() == bounds.bottomRight(),
-            "moving beyond the screen end should clamp while preserving size");
-
-    area.setPhysicalRegion(initial);
-    dragRegion(area, area.canvasGeometry().topLeft(), QPointF(10000, 10000));
-    require(area.physicalRegion().size() == QSize(2, 2) &&
-                area.physicalRegion().bottomRight() == initial.bottomRight(),
-            "resize should stop at two physical pixels without moving the opposite corner");
-    dragRegion(area, QPointF(area.width() - 1, area.height() - 1), QPointF(20, 20));
-    require(area.physicalRegion().width() > 2 && area.physicalRegion().height() > 2,
-            "a minimum-size region must still allow resizing from its bottom-right corner");
-
-    area.setPhysicalRegion(initial);
-    dragRegion(area, area.canvasGeometry().topLeft(), QPointF(-10000, -10000));
-    require(area.physicalRegion().topLeft() == bounds.topLeft() &&
-                area.physicalRegion().bottomRight() == initial.bottomRight(),
-            "resize should clamp to the screen while preserving the opposite corner");
-}
-
-void recordingAndBusyTransitionsCancelRegionGestures() {
-    for (int transition = 0; transition < 4; ++transition) {
-        ScreenRecordingAreaWindow area;
-        const QRect initial = testPhysicalRegion();
-        area.setPhysicalRegion(initial);
-        area.setInputMode(ScreenRecordingAreaWindow::InputMode::RegionEditing);
-        area.show();
-        QCoreApplication::processEvents();
-        const QPointF start = QPointF(area.pos()) + area.canvasGeometry().center();
-        sendRegionMouseEvent(area, QEvent::MouseButtonPress, start, Qt::LeftButton, Qt::LeftButton);
-        if (transition == 0) {
-            area.setRecordingState(ScreenshotToolPalette::RecordingState::Recording);
-        } else if (transition == 1) {
-            area.setRecordingState(ScreenshotToolPalette::RecordingState::Paused);
-        } else if (transition == 2) {
-            area.setDrawingBlocked(true);
-        } else {
-            area.setInputMode(ScreenRecordingAreaWindow::InputMode::PassThrough);
-        }
-        sendRegionMouseEvent(area, QEvent::MouseMove, start + QPointF(30, 20), Qt::NoButton,
-                             Qt::LeftButton);
-        sendRegionMouseEvent(area, QEvent::MouseButtonRelease, start + QPointF(30, 20),
-                             Qt::LeftButton, Qt::NoButton);
-        require(area.physicalRegion() == initial && QWidget::mouseGrabber() != &area,
-                "state, busy, and tool transitions should cancel a region gesture");
-        if (transition < 3) {
-            dragRegion(area, area.canvasGeometry().bottomRight(), QPointF(20, 20));
-            require(area.physicalRegion() == initial &&
-                        area.testAttribute(Qt::WA_TransparentForMouseEvents),
-                    "recording, paused, and busy states must lock region resizing and movement");
-        }
-        if (transition < 3) {
-            require(area.inputMode() == ScreenRecordingAreaWindow::InputMode::RegionEditing &&
-                        !area.canvas()->interactionEnabled(),
-                    "locked export settings must retain region editing mode without drawing input");
-        }
-        area.setRecordingState(ScreenshotToolPalette::RecordingState::Idle);
-        area.setDrawingBlocked(false);
-        dragRegion(area, area.canvasGeometry().bottomRight(), QPointF(20, 20));
-        require(area.physicalRegion() != initial, "returning to idle should restore edge resizing");
-    }
-}
-
-void existingSelectionsBeyondOneScreenRemainEditable() {
-    ScreenRecordingAreaWindow area;
-    const QRect bounds =
-        ScreenshotGeometryMapper::physicalRectForScreen(*QGuiApplication::primaryScreen());
-    const QRect initial(bounds.right() - 80, bounds.top() + 20, 160, 100);
-    area.setPhysicalRegion(initial);
-    area.setInputMode(ScreenRecordingAreaWindow::InputMode::RegionEditing);
+    int starts = 0;
+    int finishes = 0;
+    QObject::connect(&area, &ScreenRecordingAreaWindow::regionInteractionStarted, &area,
+                     [&]() { ++starts; });
+    QObject::connect(&area, &ScreenRecordingAreaWindow::regionInteractionFinished, &area,
+                     [&]() { ++finishes; });
+    ScreenRecordingAreaWindowTestAccess::begin(area);
+    ScreenRecordingAreaWindowTestAccess::begin(area);
+    require(starts == 1 && finishes == 0, "native entry must emit one start");
+    area.setDrawingBlocked(true);
+    require(finishes == 1, "busy transition must end an active operation");
+    ScreenRecordingAreaWindowTestAccess::begin(area);
+    require(starts == 1, "blocked input must not start an operation");
+    area.setDrawingBlocked(false);
+    ScreenRecordingAreaWindowTestAccess::begin(area);
+    area.hide();
+    ScreenRecordingAreaWindowTestAccess::finish(area);
+    require(starts == 2 && finishes == 2, "hide and duplicate native exit must finish only once");
     area.show();
-    QCoreApplication::processEvents();
-    dragRegion(area, area.canvasGeometry().center(), QPointF(-20, 0), true);
-    require(area.physicalRegion().left() < initial.left() &&
-                area.physicalRegion().size() == initial.size(),
-            "an existing selection spanning screen bounds should still be movable");
-    const QRect moved = area.physicalRegion();
-    dragRegion(area, area.canvasGeometry().bottomRight(), QPointF(-10, -10), true);
-    require(area.physicalRegion().width() < moved.width() &&
-                area.physicalRegion().height() < moved.height(),
-            "an existing selection spanning screen bounds should still be resizable");
+    area.setPhysicalRegion({40, 40, 2, 2});
+    require(ScreenRecordingAreaWindowTestAccess::edges(
+                area, QRectF(area.canvasGeometry()).center()) == Qt::Edges(),
+            "even a minimum-size region must retain an interior drag target");
 }
 
-void drawingAcrossResizeEdgesKeepsDrawingOwnership() {
+void drawingAcrossFrameEdgesRetainsDrawingOwnership() {
     ScreenRecordingAreaWindow area;
     const QRect initial = testPhysicalRegion();
     area.setPhysicalRegion(initial);
     area.setInputMode(ScreenRecordingAreaWindow::InputMode::Drawing);
     area.show();
     QCoreApplication::processEvents();
-    drawRectangle(*area.canvas(), QPointF(20, 20),
-                  QPointF(area.canvas()->width() - 2, area.canvas()->height() - 2));
-    require(area.physicalRegion() == initial && area.canvas()->canvasHistoryState().canUndo,
-            "drawing into a resize edge should finish the annotation without editing the region");
-    area.setInputMode(ScreenRecordingAreaWindow::InputMode::PassThrough);
-    const QImage surface = renderWidget(area);
-    const QPoint edge = area.canvasGeometry().topLeft() + QPoint(1, 1);
-    require(surface.pixelColor(edge).alpha() > 0,
-            "idle resize edges must have a nonzero-alpha native hit surface");
+    drawRectangle(*area.canvas(), {20, 20},
+                  {static_cast<qreal>(area.canvas()->width() - 2),
+                   static_cast<qreal>(area.canvas()->height() - 2)});
+    require(
+        area.physicalRegion() == initial && area.canvas()->canvasHistoryState().canUndo,
+        "drawing through frame hit regions must complete the annotation without editing geometry");
 }
+
+void ordinaryWindowGeometryPreservesAnnotations() {
+    ScreenRecordingAreaWindow area;
+    area.setPhysicalRegion(testPhysicalRegion());
+    area.show();
+    area.setInputMode(ScreenRecordingAreaWindow::InputMode::Drawing);
+    drawRectangle(*area.canvas(), {20, 20}, {70, 55});
+    const QByteArray history = ScreenRecordingAreaWindowTestAccess::history(area);
+    area.setInputMode(ScreenRecordingAreaWindow::InputMode::RegionEditing);
+    const QRect before = area.physicalRegion();
+    int changes = 0;
+    QObject::connect(
+        &area, &ScreenRecordingAreaWindow::physicalRegionChanged, &area, [&](const QRect& region) {
+            ++changes;
+            require(region == area.physicalRegion(), "notification must report committed geometry");
+        });
+    // Normal window events, including positions outside the starting screen, are authoritative.
+    area.move(-200, -100);
+    QCoreApplication::processEvents();
+    const QRect moved = area.physicalRegion();
+    require(moved.topLeft() != before.topLeft() && moved.size() == before.size() && changes > 0,
+            "ordinary movement must synchronize physical coordinates without clamping");
+    const QSize originalSize = area.size();
+    area.resize(originalSize - QSize(20, 10));
+    QCoreApplication::processEvents();
+    require(area.physicalRegion().width() < moved.width() &&
+                area.physicalRegion().height() < moved.height(),
+            "ordinary resize must synchronize physical dimensions");
+    area.resize(originalSize);
+    QCoreApplication::processEvents();
+    require(area.physicalRegion() == moved,
+            "shrinking and expanding must restore the same physical rectangle");
+    require(ScreenRecordingAreaWindowTestAccess::history(area) == history,
+            "window geometry changes must preserve annotation coordinates and history");
+}
+
+#if defined(Q_OS_WIN) || defined(_WIN32)
+void nativeWindowsGeometryAndInteraction() {
+    require(QGuiApplication::platformName() == QStringLiteral("windows"),
+            "native test requires Windows QPA");
+    ScreenRecordingAreaWindow area;
+    area.setInputMode(ScreenRecordingAreaWindow::InputMode::RegionEditing);
+    int starts = 0;
+    int finishes = 0;
+    QObject::connect(&area, &ScreenRecordingAreaWindow::regionInteractionStarted, &area,
+                     [&]() { ++starts; });
+    QObject::connect(&area, &ScreenRecordingAreaWindow::regionInteractionFinished, &area,
+                     [&]() { ++finishes; });
+    std::cout << "Native display count: " << QGuiApplication::screens().size() << '\n';
+    for (QScreen* display : QGuiApplication::screens()) {
+        const QRect bounds = ScreenshotGeometryMapper::physicalRectForScreen(*display);
+        const QRect selected(bounds.topLeft() + QPoint(40, 40), QSize(321, 241));
+        area.setPhysicalRegion(selected);
+        area.show();
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+        const HWND handle = reinterpret_cast<HWND>(area.winId());
+        qInfo() << display->name() << display->devicePixelRatio() << "expected" << selected
+                << "observed" << area.physicalRegion() << "logical" << area.geometry();
+        require(area.physicalRegion() == selected,
+                "opening on each display must preserve exact physical selection");
+        RECT initialClient{};
+        POINT initialOrigin{};
+        require(GetClientRect(handle, &initialClient) && ClientToScreen(handle, &initialOrigin),
+                "initial native geometry must exist");
+        const QMargins initialInsets(
+            selected.left() - initialOrigin.x, selected.top() - initialOrigin.y,
+            initialOrigin.x + initialClient.right - selected.x() - selected.width(),
+            initialOrigin.y + initialClient.bottom - selected.y() - selected.height());
+        const auto verifyClient = [&]() {
+            RECT client{};
+            POINT origin{};
+            require(GetClientRect(handle, &client) && ClientToScreen(handle, &origin),
+                    "native client geometry must be readable");
+            const QRect clientGeometry(origin.x, origin.y, client.right - client.left,
+                                       client.bottom - client.top);
+            if (area.physicalRegion() != clientGeometry.marginsRemoved(initialInsets)) {
+                qInfo() << "Geometry mismatch" << "client" << clientGeometry << "capture"
+                        << area.physicalRegion() << "insets" << initialInsets << "logical"
+                        << area.geometry();
+            }
+            require(area.physicalRegion() == clientGeometry.marginsRemoved(initialInsets),
+                    "native events must synchronize capture to actual client pixels");
+        };
+        verifyClient();
+        const QRect next(bounds.topLeft() + QPoint(60, 50), QSize(409, 307));
+        require(SetWindowPos(handle, nullptr, next.x(), next.y(), next.width(), next.height(),
+                             SWP_NOZORDER | SWP_NOACTIVATE) != 0,
+                "native resize must succeed");
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+        verifyClient();
+        // Physical changes can round to the same QWidget size at fractional DPI.
+        for (const int nativeWidth : {410, 411, 409}) {
+            SetWindowPos(handle, nullptr, 0, 0, nativeWidth, next.height(),
+                         SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+            verifyClient();
+        }
+        MINMAXINFO limits{};
+        SendMessageW(handle, WM_GETMINMAXINFO, 0, reinterpret_cast<LPARAM>(&limits));
+        require(
+            limits.ptMinTrackSize.x - initialInsets.left() - initialInsets.right() == 2 &&
+                limits.ptMinTrackSize.y - initialInsets.top() - initialInsets.bottom() == 2,
+            "native minimum tracking size must preserve two capture pixels after frame padding");
+        const QRect physical = area.physicalRegion();
+        const int x = physical.center().x();
+        const int y = physical.center().y();
+        const auto hit = [&](QPoint position) {
+            return SendMessageW(handle, WM_NCHITTEST, 0, MAKELPARAM(position.x(), position.y()));
+        };
+        require(hit({x, y}) == HTCAPTION, "Export Settings center must delegate native movement");
+        const std::pair<QPoint, LRESULT> targets[] = {{{physical.left(), y}, HTLEFT},
+                                                      {{physical.right(), y}, HTRIGHT},
+                                                      {{x, physical.top()}, HTTOP},
+                                                      {{x, physical.bottom()}, HTBOTTOM},
+                                                      {physical.topLeft(), HTTOPLEFT},
+                                                      {physical.topRight(), HTTOPRIGHT},
+                                                      {physical.bottomLeft(), HTBOTTOMLEFT},
+                                                      {physical.bottomRight(), HTBOTTOMRIGHT},
+                                                      {{x, y}, HTCAPTION}};
+        for (const auto& [point, expected] : targets) {
+            require(hit(point) == expected,
+                    "all native hit targets must identify the correct operation");
+            const int previousStarts = starts;
+            const int previousFinishes = finishes;
+            POINT cursor{};
+            GetCursorPos(&cursor);
+            if (expected == HTCAPTION) {
+                // SC_DRAGMOVE requires a real held mouse button. Exercise the same
+                // system move loop through its keyboard command without injecting input.
+                PostMessageW(handle, WM_SYSCOMMAND, SC_MOVE, 0);
+            } else {
+                SendMessageW(handle, WM_NCLBUTTONDOWN, static_cast<WPARAM>(expected),
+                             MAKELPARAM(point.x(), point.y()));
+            }
+            QTimer cancel;
+            QObject::connect(&cancel, &QTimer::timeout, &area,
+                             [handle]() { SendMessageW(handle, WM_CANCELMODE, 0, 0); });
+            cancel.start(0);
+            PostMessageW(handle, WM_CANCELMODE, 0, 0);
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+            cancel.stop();
+            if (expected == HTCAPTION) {
+                SetCursorPos(cursor.x, cursor.y);
+            }
+            qInfo() << "Native interaction" << expected << "starts" << starts - previousStarts
+                    << "finishes" << finishes - previousFinishes;
+            require(starts == previousStarts + 1 && finishes == previousFinishes + 1,
+                    "system move/resize must have one balanced interaction lifecycle");
+            verifyClient();
+        }
+        area.setInputMode(ScreenRecordingAreaWindow::InputMode::Drawing);
+        require(hit(physical.topLeft()) == HTCLIENT && hit({x, y}) == HTCLIENT,
+                "drawing must disable both native resize and move targets");
+        area.setInputMode(ScreenRecordingAreaWindow::InputMode::PassThrough);
+        require(hit(physical.topLeft()) == HTTRANSPARENT && hit({x, y}) == HTTRANSPARENT,
+                "pass-through must release both native resize and move targets");
+        area.setInputMode(ScreenRecordingAreaWindow::InputMode::Drawing);
+        drawRectangle(*area.canvas(), {20, 20}, {70, 55});
+        const QByteArray history = ScreenRecordingAreaWindowTestAccess::history(area);
+        area.setInputMode(ScreenRecordingAreaWindow::InputMode::RegionEditing);
+        for (QScreen* destination : QGuiApplication::screens()) {
+            if (destination == display) {
+                continue;
+            }
+            const QRect destinationBounds =
+                ScreenshotGeometryMapper::physicalRectForScreen(*destination);
+            SetWindowPos(handle, nullptr, destinationBounds.x() + 60, destinationBounds.y() + 60, 0,
+                         0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+            verifyClient();
+            require(area.screen() == destination &&
+                        area.physicalRegion().intersects(destinationBounds),
+                    "an existing native window must move onto another display without clamping");
+            require(ScreenRecordingAreaWindowTestAccess::history(area) == history,
+                    "native display transitions must preserve annotations");
+        }
+    }
+}
+#endif
+
 } // namespace
 
 int main(int argc, char** argv) {
     QApplication application(argc, argv);
+#if defined(Q_OS_WIN) || defined(_WIN32)
+    if (application.arguments().contains(QStringLiteral("--native-geometry-only"))) {
+        nativeWindowsGeometryAndInteraction();
+        return 0;
+    }
+#endif
     geometryAndTransparentCanvasFollowThePhysicalSelection();
     inputModesOwnOnlyDrawingInputAndRestoreRequestedState();
     drawingSurfaceFollowsEffectiveInputMode();
     wheelAndEscapeRespectDrawingOwnership();
     annotationsPersistAcrossStatesAndClearOnlyForANewRegion();
-    idleEdgesAndCornersResizePhysicalRegion();
-    exportSettingsMoveAndClampTheRegion();
-    recordingAndBusyTransitionsCancelRegionGestures();
-    existingSelectionsBeyondOneScreenRemainEditable();
-    drawingAcrossResizeEdgesKeepsDrawingOwnership();
+    geometryEditingIsOneCapability();
+    interactionBoundariesAreIdempotentAndCancelOnStateChanges();
+    ordinaryWindowGeometryPreservesAnnotations();
+    drawingAcrossFrameEdgesRetainsDrawingOwnership();
     return 0;
 }

--- a/snow_shot/tests/screen_recording_controller_tests.cpp
+++ b/snow_shot/tests/screen_recording_controller_tests.cpp
@@ -17,8 +17,14 @@
 #include <QMouseEvent>
 #include <QWindow>
 #include <QScreen>
+#include <QPointer>
+#include <QTimer>
+#include <QMessageBox>
+#include "widgets/color_picker.h"
+#include <future>
 #ifdef Q_OS_WIN
 #include <qt_windows.h>
+int recordingToolbarAcrossNativeDisplays(bool startCapture);
 #endif
 #include <atomic>
 #include <cstdlib>
@@ -29,6 +35,10 @@ namespace {
 SnowCaptureRecordingSession session;
 int starts = 0;
 std::atomic<int> exports = 0;
+std::shared_future<void> exportGate;
+std::promise<void>* exportEntered = nullptr;
+std::atomic<bool> failExport = false;
+std::atomic<int> destroyedSessions = 0;
 void require(bool condition, const char* message) {
     if (!condition) {
         std::cerr << message << '\n';
@@ -44,6 +54,97 @@ ScreenshotToolPalette* palette() {
     }
     require(false, "recording toolbar must exist");
     return nullptr;
+}
+
+class ErrorObserver final : public QObject {
+  public:
+    int shown = 0;
+    bool eventFilter(QObject* watched, QEvent* event) override {
+        if (event->type() == QEvent::Show) {
+            if (auto* dialog = qobject_cast<QMessageBox*>(watched)) {
+                ++shown;
+                QTimer::singleShot(0, dialog, &QMessageBox::accept);
+            }
+        }
+        return false;
+    }
+};
+
+void waitForIdle(ScreenRecordingController& controller) {
+    QElapsedTimer deadline;
+    deadline.start();
+    while (controller.isRecording() && deadline.elapsed() < 3000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents, 100);
+    }
+    require(!controller.isRecording(), "controlled finalization must return to idle");
+}
+
+int recordingWindowCount() {
+    int count = 0;
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        count += qobject_cast<ScreenRecordingAreaWindow*>(widget) != nullptr ||
+                 qobject_cast<ScreenRecordingToolbarWindow*>(widget) != nullptr;
+    }
+    return count;
+}
+
+void closeAndStopHaveIndependentUiLifetimes() {
+    ErrorObserver errors;
+    qApp->installEventFilter(&errors);
+    for (const bool close : {false, true}) {
+        for (const bool failure : {false, true}) {
+            ScreenRecordingController controller;
+            require(recordingWindowCount() == 0,
+                    "constructing a controller must not create windows");
+            controller.open({40, 40, 320, 240});
+            auto* toolbar = qobject_cast<ScreenRecordingToolbarWindow*>(palette()->window());
+            QPointer<ScreenRecordingToolbarWindow> previousToolbar(toolbar);
+            std::promise<void> release;
+            std::promise<void> entered;
+            auto enteredFuture = entered.get_future();
+            exportGate = release.get_future().share();
+            exportEntered = &entered;
+            failExport = failure;
+            const int previousDestroyed = destroyedSessions;
+            const int previousErrors = errors.shown;
+            controller.startRecording();
+            QCoreApplication::processEvents();
+            require(controller.isRecording(), "fake backend must start");
+            if (close) {
+                // Exercise the native close path as well as the toolbar command.
+                toolbar->close();
+            } else {
+                palette()->recordingStopRequested();
+            }
+            require(enteredFuture.wait_for(std::chrono::seconds(2)) == std::future_status::ready,
+                    "stop must reach the controlled backend");
+            require(controller.isOpen() != close, "only Close must detach the UI during export");
+            QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+            require(previousToolbar.isNull() == close && recordingWindowCount() == (close ? 0 : 2),
+                    "Close must destroy UI before backend finalization, while Stop retains it");
+            controller.open({80, 80, 320, 240});
+            require(recordingWindowCount() == (close ? 0 : 2),
+                    "busy finalization must reject reopen");
+            release.set_value();
+            waitForIdle(controller);
+            require(destroyedSessions == previousDestroyed + 1,
+                    "backend must be destroyed exactly once");
+            require(errors.shown == previousErrors + (failure ? 1 : 0),
+                    "export failure must be reported even after Close");
+            require(recordingWindowCount() == (close ? 0 : 2),
+                    "completion must not recreate closed UI");
+            if (!close) {
+                require(previousToolbar && previousToolbar->isVisible(),
+                        "Stop must keep the original UI usable");
+                palette()->recordingCloseRequested();
+                QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+            }
+            exportEntered = nullptr;
+            exportGate = {};
+            failExport = false;
+        }
+    }
+    qApp->removeEventFilter(&errors);
 }
 
 void requireToolbarAboveArea(ScreenRecordingAreaWindow* area) {
@@ -77,6 +178,92 @@ void requireToolbarAboveArea(ScreenRecordingAreaWindow* area) {
     require(toolbar->windowHandle()->transientParent() == area->windowHandle(),
             "recording toolbar must retain the area as its transient owner");
     area->setInputMode(previousInputMode);
+}
+
+void recordingToolbarReconcilesFrameBeforeShowing() {
+    ScreenRecordingToolbarWindow toolbar;
+    QScreen* screen = QGuiApplication::primaryScreen();
+    require(screen != nullptr, "placement test requires a screen");
+    const QRect region = ScreenshotGeometryMapper::physicalRectForScreen(*screen);
+    toolbar.placeForPhysicalRegion(region);
+    toolbar.showAndActivate();
+    QCoreApplication::processEvents();
+    toolbar.hide();
+    const QSize expected = toolbar.windowSizeHint();
+    const QPoint anchor = toolbar.contentPosition();
+    // Model Windows retaining the old physical frame after a DPI transition,
+    // while the host already contains the destination display's logical layout.
+    toolbar.resize(expected.width() / 2, expected.height());
+    toolbar.showAndActivate();
+    require(toolbar.size() == expected &&
+                toolbar.rect().contains(toolbar.paletteHost()->geometry()),
+            "showing recording controls must reconcile the frame before painting");
+    require(toolbar.contentPosition() == anchor,
+            "reconciling the recording frame must preserve its content anchor");
+    toolbar.beginRegionInteraction();
+    toolbar.resize(expected.width() / 2, expected.height());
+    toolbar.endRegionInteraction(region);
+    require(toolbar.size() == expected &&
+                toolbar.rect().contains(toolbar.paletteHost()->geometry()),
+            "restoring recording controls after area interaction must reconcile the frame");
+}
+
+void recordingToolbarPlacementAcrossDisplays() {
+    ScreenRecordingAreaWindow area;
+    ScreenRecordingToolbarWindow toolbar;
+    toolbar.setTransientOwnerWindow(&area);
+    QRegion desktop;
+    for (QScreen* screen : QGuiApplication::screens()) {
+        desktop += ScreenshotGeometryMapper::physicalRectForScreen(*screen);
+    }
+    for (QScreen* screen : QGuiApplication::screens()) {
+        const QRect bounds = ScreenshotGeometryMapper::physicalRectForScreen(*screen);
+        for (int offset : {-bounds.width() / 3, 0, bounds.width() / 3}) {
+            for (int height : {100, bounds.height() - 80}) {
+                const QRect region(bounds.left() + offset, bounds.top() + 40, bounds.width() / 2,
+                                   height);
+                // Only selections within the captured desktop can originate in the UI.
+                if (!QRegion(region).subtracted(desktop).isEmpty()) {
+                    continue;
+                }
+                area.setPhysicalRegion(region);
+                toolbar.placeForPhysicalRegion(region);
+                area.show();
+                toolbar.showAndActivate();
+                for (int pass = 0; pass < 5; ++pass) {
+                    QCoreApplication::processEvents();
+                }
+                require(toolbar.size() == toolbar.windowSizeHint() &&
+                            toolbar.rect().contains(toolbar.paletteHost()->geometry()),
+                        "cross-display placement must reconcile the frame before opening panels");
+                toolbar.palette()->setActiveTool(ScreenshotToolPalette::Tool::Shape);
+                QCoreApplication::processEvents();
+                const QPoint position = toolbar.contentPosition();
+                const QRect content = toolbar.occupiedContentRect();
+                const QRect visible = content.translated(position);
+                QScreen* target = ScreenshotGeometryMapper::screenForPhysicalRect(region);
+                const QRect logicalBounds = target->geometry();
+                require(
+                    visible.top() >= logicalBounds.top() &&
+                        visible.bottom() <= logicalBounds.bottom(),
+                    "recording rows must fit the selected display after cross-display placement");
+                if (visible.width() <= logicalBounds.width()) {
+                    require(logicalBounds.contains(visible),
+                            "recording rows must remain horizontally inside the selected display");
+                }
+                require(toolbar.rect().contains(
+                            content.translated(toolbar.contentPosition() - toolbar.pos())),
+                        "recording rows must fit the native frame after cross-display placement");
+                toolbar.placeForPhysicalRegion(region);
+                QCoreApplication::processEvents();
+                require(
+                    toolbar.contentPosition() == position &&
+                        toolbar.occupiedContentRect() == content,
+                    "repeated cross-display placement must keep the committed layout and anchor");
+                toolbar.palette()->clearActiveTool();
+            }
+        }
+    }
 }
 
 void recordingSecondaryPanelsStayOnScreen() {
@@ -155,7 +342,9 @@ snow_capture_recording_session_create_direct(const SnowCaptureDirectRecordingCon
     *result = &session;
     return SNOW_CAPTURE_RESULT_OK;
 }
-void snow_capture_recording_session_destroy(SnowCaptureRecordingSession*) {}
+void snow_capture_recording_session_destroy(SnowCaptureRecordingSession*) {
+    ++destroyedSessions;
+}
 uint8_t snow_capture_recording_session_start(SnowCaptureRecordingSession*) {
     ++starts;
     return 1;
@@ -168,7 +357,13 @@ uint8_t snow_capture_recording_session_resume(SnowCaptureRecordingSession*) {
 }
 SnowCaptureResult snow_capture_recording_session_stop(SnowCaptureRecordingSession*) {
     ++exports;
-    return SNOW_CAPTURE_RESULT_OK;
+    if (exportEntered != nullptr) {
+        exportEntered->set_value();
+    }
+    if (exportGate.valid()) {
+        exportGate.wait();
+    }
+    return failExport ? SNOW_CAPTURE_RESULT_INVALID_ARGUMENT : SNOW_CAPTURE_RESULT_OK;
 }
 uint8_t snow_capture_recording_session_state(const SnowCaptureRecordingSession*,
                                              SnowCaptureRecordingState* state) {
@@ -193,6 +388,21 @@ int main(int argc, char** argv) {
             "test output directory must be set");
     require(RecordingSettings().setHideToolbarInRecording(false),
             "capture exclusion must be disabled for fake backend");
+#ifdef Q_OS_WIN
+    if (app.arguments().contains(QStringLiteral("--native-toolbar-display-only")) ||
+        app.arguments().contains(QStringLiteral("--native-toolbar-ready-display-only"))) {
+        const int result = recordingToolbarAcrossNativeDisplays(
+            app.arguments().contains(QStringLiteral("--native-toolbar-display-only")));
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        ApplicationStorage::instance().shutdown();
+        return result;
+    }
+#endif
+    recordingToolbarReconcilesFrameBeforeShowing();
+    recordingToolbarPlacementAcrossDisplays();
+    if (app.arguments().contains(QStringLiteral("--placement-only"))) {
+        return 0;
+    }
     recordingSecondaryPanelsStayOnScreen();
     {
         ScreenRecordingController controller;
@@ -206,6 +416,28 @@ int main(int argc, char** argv) {
         }
         require(area != nullptr, "recording area must exist");
         requireToolbarAboveArea(area);
+        auto* toolbar = qobject_cast<ScreenRecordingToolbarWindow*>(palette()->window());
+        auto* picker = toolbar->palette()->findChild<adqt::widgets::AdColorPicker*>(
+            QStringLiteral("screenRecordingMouseTrailColor"));
+        require(picker != nullptr, "export settings must expose the trail color popup");
+        picker->setPopupVisible(true);
+        QCoreApplication::processEvents();
+        require(picker->popupVisible(), "test popup must open");
+        const QPoint toolbarPosition = toolbar->pos();
+        area->regionInteractionStarted();
+        require(!picker->popupVisible(), "geometry interaction must dismiss export popups");
+        require(!toolbar->isVisible(), "native interaction must hide the toolbar");
+        area->move(area->pos() + QPoint(20, 10));
+        QCoreApplication::processEvents();
+        require(!toolbar->isVisible() && toolbar->pos() == toolbarPosition,
+                "intermediate geometry must not show or reposition the toolbar");
+        area->regionInteractionFinished();
+        require(toolbar->isVisible(), "finishing interaction must restore the toolbar");
+        const QPoint finalPosition = toolbar->contentPosition();
+        toolbar->placeForPhysicalRegion(area->physicalRegion());
+        require(toolbar->contentPosition() == finalPosition,
+                "restored toolbar must use final geometry");
+        controller.open(region);
         auto* canvas = area->canvas();
         require(palette()->activateDrawingShortcut(QStringLiteral("shape")),
                 "drawing shortcut must activate the shape tool");
@@ -222,10 +454,21 @@ int main(int argc, char** argv) {
         controller.open(region);
         require(canvas->canvasHistoryState().canUndo,
                 "opening an already visible region must preserve its drawing");
+        QPointer<ScreenRecordingAreaWindow> closedArea(area);
+        QPointer<ScreenRecordingToolbarWindow> closedToolbar(
+            qobject_cast<ScreenRecordingToolbarWindow*>(palette()->window()));
         palette()->recordingCloseRequested();
+        require(!controller.isOpen(), "Close must detach the session immediately");
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+        require(closedArea.isNull() && closedToolbar.isNull(), "Close must destroy both windows");
         controller.open(region);
-        require(area->isVisible() && area->canvas() == canvas,
-                "a new recording session must reuse the area and canvas");
+        for (auto* widget : QApplication::topLevelWidgets()) {
+            if (auto* candidate = qobject_cast<ScreenRecordingAreaWindow*>(widget)) {
+                area = candidate;
+            }
+        }
+        canvas = area->canvas();
+        require(area->isVisible(), "reopening must create a visible fresh session");
         requireToolbarAboveArea(area);
         require(!canvas->canvasHistoryState().canUndo && !canvas->canvasHistoryState().canRedo,
                 "a new session at the same rectangle must clear drawing and history");
@@ -252,11 +495,12 @@ int main(int argc, char** argv) {
             palette()->recordingCloseRequested();
             controller.open(QRect(80, 80, 320, 240));
         }
+        QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
         int toolbarCount = 0;
         for (auto* widget : QApplication::topLevelWidgets()) {
             toolbarCount += qobject_cast<ScreenRecordingToolbarWindow*>(widget) != nullptr;
         }
-        require(toolbarCount == 1, "reopening must reuse the controller's existing toolbar");
+        require(toolbarCount == 1, "reopening must leave only the current toolbar alive");
         controller.startRecording();
         controller.open(QRect(120, 80, 320, 240));
         QCoreApplication::processEvents();
@@ -293,6 +537,7 @@ int main(int argc, char** argv) {
     QCoreApplication::processEvents();
     QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
     require(starts == 1, "destroying the controller must cancel a queued recording start");
+    closeAndStopHaveIndependentUiLifetimes();
     ApplicationStorage::instance().shutdown();
     return 0;
 }

--- a/snow_shot/tests/screen_recording_geometry_tests.cpp
+++ b/snow_shot/tests/screen_recording_geometry_tests.cpp
@@ -19,6 +19,38 @@ void require(bool condition, const char* message) {
     }
 }
 
+void observedNativeGeometryFollowsDisplaysWithoutRescalingPhysicalCoordinates() {
+    // Include negative origins, a display seam, odd extents, and the minimum-size window.
+    for (const QRect client : {QRect(-1920, -200, 647, 367), QRect(-80, 40, 320, 240),
+                               QRect(3000, 180, 1286, 726), QRect(40, 40, 8, 8)}) {
+        for (const qreal scale : {1.0, 1.25, 1.5, 1.75, 2.0}) {
+            const auto observed = recording::screenRecordingObservedGeometry(client, scale);
+            require(observed.physicalRegion == client.adjusted(3, 3, -3, -3),
+                    "DPI and display origins must not rescale native capture coordinates");
+            require(qAbs(observed.selectionRect.width() * scale - observed.physicalRegion.width()) <
+                            0.0001 &&
+                        qAbs(observed.selectionRect.height() * scale -
+                             observed.physicalRegion.height()) < 0.0001,
+                    "fractional logical layout must cover exactly the physical capture pixels");
+            const auto border = recording::screenRecordingAreaBorderGeometry(
+                observed.frameRect, observed.selectionRect, observed.paddingWidth);
+            require(qAbs(border.top.height() * scale - 2.0) < 0.0001 &&
+                        qAbs(border.right.width() * scale - 2.0) < 0.0001,
+                    "native resizing must retain the physical frame width");
+            require(
+                qAbs(observed.frameRect.width() * scale - client.width()) < 0.0001,
+                "fractional-DPI borders must reach the native client edge without rounding loss");
+        }
+    }
+    const auto rounded = recording::screenRecordingObservedGeometry(QRect(36, 36, 329, 249), 1.5,
+                                                                    QMargins(4, 4, 4, 4));
+    require(rounded.physicalRegion == QRect(40, 40, 321, 241),
+            "Qt's fractional-DPI outer rounding must not change the initial screenshot selection");
+    require(!recording::screenRecordingObservedGeometry(QRect(0, 0, 7, 8), 1.25)
+                 .physicalRegion.isValid(),
+            "undersized native geometry must not publish an invalid capture selection");
+}
+
 void recordingFrameStaysOutsideTheSelection(qreal scale) {
     const QRectF selection(300.4, 200.8, 641.2, 359.6);
     const recording::ScreenRecordingAreaFrameGeometry geometry =
@@ -112,15 +144,14 @@ void physicalSelectionMapsToItsLogicalSubregion() {
 void toolbarUsesBottomRightThenTopRight() {
     const QRect bounds(0, 0, 1920, 1080);
     const QRect toolbarRect(12, 8, 520, 48);
-    const ScreenshotToolbarPlacementGeometry toolbarPlacement{
-        toolbarRect, {}, toolbarRect};
+    const ScreenshotToolbarPlacementGeometry toolbarPlacement{toolbarRect, {}, toolbarRect};
     const QRect upperRegion(500, 200, 700, 400);
     const ScreenshotAnchoredToolbarPlacement bottomRightPlacement =
         ScreenshotGeometryMapper::anchoredToolbarPlacement(
             QPoint(upperRegion.left() + upperRegion.width(),
                    upperRegion.top() + upperRegion.height()),
-            QPoint(upperRegion.left() + upperRegion.width(), upperRegion.top()),
-            toolbarPlacement, toolbarPlacement, bounds, 4);
+            QPoint(upperRegion.left() + upperRegion.width(), upperRegion.top()), toolbarPlacement,
+            toolbarPlacement, bounds, 4);
     const QRect bottomRightToolbar = toolbarRect.translated(bottomRightPlacement.contentPosition);
     require(!bottomRightPlacement.usesTopRightPlacement,
             "toolbar should prefer the recording region bottom-right corner");
@@ -134,8 +165,8 @@ void toolbarUsesBottomRightThenTopRight() {
         ScreenshotGeometryMapper::anchoredToolbarPlacement(
             QPoint(lowerRegion.left() + lowerRegion.width(),
                    lowerRegion.top() + lowerRegion.height()),
-            QPoint(lowerRegion.left() + lowerRegion.width(), lowerRegion.top()),
-            toolbarPlacement, toolbarPlacement, bounds, 4);
+            QPoint(lowerRegion.left() + lowerRegion.width(), lowerRegion.top()), toolbarPlacement,
+            toolbarPlacement, bounds, 4);
     const QRect topRightToolbar = toolbarRect.translated(topRightPlacement.contentPosition);
     require(topRightPlacement.usesTopRightPlacement,
             "toolbar should use top-right when bottom-right lacks vertical space");
@@ -148,8 +179,7 @@ void toolbarUsesBottomRightThenTopRight() {
 void toolbarRemainsInsideTheAvailableScreen() {
     const QRect bounds(0, 0, 800, 600);
     const QRect toolbarRect(10, 6, 1000, 48);
-    const ScreenshotToolbarPlacementGeometry toolbarPlacement{
-        toolbarRect, {}, toolbarRect};
+    const ScreenshotToolbarPlacementGeometry toolbarPlacement{toolbarRect, {}, toolbarRect};
     const QRect region(5, 570, 100, 20);
     const ScreenshotAnchoredToolbarPlacement placement =
         ScreenshotGeometryMapper::anchoredToolbarPlacement(
@@ -177,13 +207,14 @@ void toolbarAnchorsTheMainRowAndUsesTheVisibleSecondaryRow() {
         QRect(100, 16, 200, 84),
     };
     const ScreenshotAnchoredToolbarPlacement placement =
-        ScreenshotGeometryMapper::anchoredToolbarPlacement(
-            QPoint(500, 200), QPoint(500, 500), bottom, top, bounds, 4);
+        ScreenshotGeometryMapper::anchoredToolbarPlacement(QPoint(500, 200), QPoint(500, 500),
+                                                           bottom, top, bounds, 4);
     require(!placement.usesTopRightPlacement,
             "visible bottom content should remain at the bottom-right anchor");
 
     const QRect main = bottom.mainToolbarContentRect.translated(placement.contentPosition);
-    const QRect secondary = bottom.secondaryToolbarContentRect.translated(placement.contentPosition);
+    const QRect secondary =
+        bottom.secondaryToolbarContentRect.translated(placement.contentPosition);
     require(main.right() == 500 && main.top() == 205,
             "bottom placement should anchor the main row's top-right corner");
     require(secondary.right() == 500 && secondary.top() == 249 &&
@@ -196,8 +227,8 @@ void toolbarAnchorsTheMainRowAndUsesTheVisibleSecondaryRow() {
         QRect(100, 0, 200, 700),
     };
     const ScreenshotAnchoredToolbarPlacement topPlacement =
-        ScreenshotGeometryMapper::anchoredToolbarPlacement(
-            QPoint(500, 750), QPoint(500, 500), crampedBottom, top, bounds, 4);
+        ScreenshotGeometryMapper::anchoredToolbarPlacement(QPoint(500, 750), QPoint(500, 500),
+                                                           crampedBottom, top, bounds, 4);
     require(topPlacement.usesTopRightPlacement,
             "placement should fall back to the top-right anchor when bottom content does not fit");
     const QRect topMain = top.mainToolbarContentRect.translated(topPlacement.contentPosition);
@@ -205,8 +236,7 @@ void toolbarAnchorsTheMainRowAndUsesTheVisibleSecondaryRow() {
         top.secondaryToolbarContentRect.translated(topPlacement.contentPosition);
     require(topMain.right() == 500 && topMain.bottom() == 495,
             "top placement should anchor the main row's bottom-right corner");
-    require(topSecondary.right() == 500 &&
-                topMain.top() - topSecondary.bottom() - 1 == 4,
+    require(topSecondary.right() == 500 && topMain.top() - topSecondary.bottom() - 1 == 4,
             "top placement should right-align and space the active secondary row");
 }
 
@@ -321,6 +351,7 @@ void clarityBoundsFollowCaptureOrientation() {
 
 int main(int argc, char** argv) {
     QGuiApplication application(argc, argv);
+    observedNativeGeometryFollowsDisplaysWithoutRescalingPhysicalCoordinates();
     physicalSelectionMapsToItsLogicalSubregion();
     recordingFrameStaysOutsideTheSelection(1.0);
     recordingFrameStaysOutsideTheSelection(1.5);

--- a/snow_shot/tests/screen_recording_shortcut_tests.cpp
+++ b/snow_shot/tests/screen_recording_shortcut_tests.cpp
@@ -201,8 +201,9 @@ void recordingSelectionEditsAnnotationsAndPreservesPassThrough() {
         require(canvas.interactionEnabled(), "selection must resume after busy operations");
         select->click();
         require(!palette.activeTool().has_value() && !canvas.interactionEnabled() &&
-                    area.inputMode() == ScreenRecordingAreaWindow::InputMode::PassThrough,
-                "clicking active Select must return to pass-through mode");
+                    area.inputMode() == ScreenRecordingAreaWindow::InputMode::RegionEditing &&
+                    palette.recordingExportSettingsVisible(),
+                "clicking active Select must return to Export Settings");
         select->click();
         settings->click();
         require(!palette.activeTool().has_value() && palette.recordingExportSettingsVisible() &&
@@ -216,6 +217,16 @@ void recordingSelectionEditsAnnotationsAndPreservesPassThrough() {
         emit palette.selectRequested();
         require(area.inputMode() == ScreenRecordingAreaWindow::InputMode::PassThrough,
                 "deactivating drawing must keep the existing pass-through behavior");
+        require(palette.activateDrawingShortcut(QStringLiteral("shape")) &&
+                    palette.activeTool() == ScreenshotToolPalette::Tool::Shape,
+                "drawing shortcut must activate its tool");
+        require(palette.activateDrawingShortcut(QStringLiteral("shape")) &&
+                    !palette.activeTool().has_value() && palette.recordingExportSettingsVisible() &&
+                    area.inputMode() == ScreenRecordingAreaWindow::InputMode::RegionEditing,
+                "repeating a drawing shortcut must switch only to Export Settings");
+        settings->click();
+        require(palette.recordingExportSettingsVisible(),
+                "repeated Export Settings must stay selected");
     }
 
     select->click();
@@ -401,6 +412,7 @@ void recordingControlShortcutsFollowButtonsAndSettings() {
     press(toolbar, Qt::Key_E, Qt::ControlModifier);
     require(total() == before, "reconfiguration must remove the old binding immediately");
     press(toolbar, Qt::Key_F12);
+    palette.clearActiveTool();
     QWidget popup(&toolbar, Qt::Tool);
     emit palette.materializedScope(&popup);
     popup.show();
@@ -472,6 +484,7 @@ void recordingShortcutsFollowBothWindowsAndConfiguredKeys() {
     });
 
     auto shortcuts = std::make_unique<ScreenRecordingShortcutController>(area, toolbar);
+    area.setInputMode(ScreenRecordingAreaWindow::InputMode::RegionEditing);
     area.show();
     toolbar.show();
     focus(toolbar);
@@ -488,6 +501,7 @@ void recordingShortcutsFollowBothWindowsAndConfiguredKeys() {
         for (const auto mode : {ScreenRecordingAreaWindow::InputMode::PassThrough,
                                 ScreenRecordingAreaWindow::InputMode::RegionEditing,
                                 ScreenRecordingAreaWindow::InputMode::Drawing}) {
+            palette->clearActiveTool();
             area.setInputMode(mode);
             palette->clearActiveTool();
             focus(toolbar);
@@ -500,6 +514,7 @@ void recordingShortcutsFollowBothWindowsAndConfiguredKeys() {
     }
     for (const auto state : {ScreenshotToolPalette::RecordingState::Recording,
                              ScreenshotToolPalette::RecordingState::Paused}) {
+        palette->clearActiveTool();
         area.setRecordingState(state);
         area.setInputMode(ScreenRecordingAreaWindow::InputMode::PassThrough);
         palette->clearActiveTool();
@@ -540,6 +555,7 @@ void recordingShortcutsFollowBothWindowsAndConfiguredKeys() {
     require(history.setShortcuts(QStringLiteral("undo"), {QStringLiteral("F11")}) &&
                 drawing.setArrow({QStringLiteral("F11")}),
             "drawing and history shortcut collision should be configurable");
+    palette->clearActiveTool();
     const int arrowsBeforeUndo = arrows;
     press(toolbar, Qt::Key_F11);
     require(undos == 3 && arrows == arrowsBeforeUndo,
@@ -560,9 +576,11 @@ void recordingShortcutsFollowBothWindowsAndConfiguredKeys() {
     press(toolbar, Qt::Key_F10, Qt::NoModifier, true);
     require(shapes == before, "held drawing keys must not repeatedly activate tools");
     press(toolbar, Qt::Key_F10);
-    require(shapes == before && !palette->activeTool().has_value() &&
-                area.inputMode() == ScreenRecordingAreaWindow::InputMode::PassThrough,
-            "repeating a recording tool shortcut must deselect it like a button click");
+    require(
+        shapes == before && !palette->activeTool().has_value() &&
+            palette->recordingExportSettingsVisible() &&
+            area.inputMode() == ScreenRecordingAreaWindow::InputMode::RegionEditing,
+        "repeating a recording tool shortcut must return to Export Settings like a button click");
 
     area.setDrawingBlocked(true);
     press(toolbar, Qt::Key_F10);
@@ -579,7 +597,13 @@ void recordingShortcutsFollowBothWindowsAndConfiguredKeys() {
     require(shapes == before && undos == 3, "text editors must retain shortcut input");
     editor.setReadOnly(true);
     press(editor, Qt::Key_F10);
-    require(shapes == ++before, "read-only text controls should allow toolbar shortcuts");
+    require(shapes == ++before && palette->activeTool() == ScreenshotToolPalette::Tool::Shape,
+            "read-only text controls must allow drawing tool activation");
+    press(editor, Qt::Key_F10);
+    require(
+        shapes == before && palette->recordingExportSettingsVisible() &&
+            !palette->activeTool().has_value(),
+        "read-only text controls must allow the active-tool shortcut to return to Export Settings");
     editor.hide();
     focus(toolbar);
 
@@ -602,6 +626,7 @@ void recordingShortcutsFollowBothWindowsAndConfiguredKeys() {
     unrelated.show();
     press(unrelated, Qt::Key_F10);
     require(shapes == before, "unrelated windows must not dispatch recording shortcuts");
+    palette->clearActiveTool();
     QWidget popup(&toolbar, Qt::Tool);
     emit palette->materializedScope(&popup);
     popup.show();
@@ -619,6 +644,7 @@ void recordingShortcutsFollowBothWindowsAndConfiguredKeys() {
     shortcuts.reset();
     press(toolbar, Qt::Key_F10);
     require(shapes == before, "destroyed shortcut controller must release all bindings");
+    palette->clearActiveTool();
     shortcuts = std::make_unique<ScreenRecordingShortcutController>(area, toolbar);
     palette->clearActiveTool();
     press(toolbar, Qt::Key_F10);

--- a/snow_shot/tests/screen_recording_toolbar_display_tests.cpp
+++ b/snow_shot/tests/screen_recording_toolbar_display_tests.cpp
@@ -1,0 +1,289 @@
+#include "snow_shot/presentation/screenrecordingcontroller.h"
+#include "snow_shot/presentation/screenrecordingareawindow.h"
+#include "snow_shot/presentation/screenrecordingtoolbarwindow.h"
+#include "snow_shot/presentation/screenshotgeometry.h"
+#include "snow_shot/presentation/screenshottoolpalettehost.h"
+#include "widgets/button.h"
+
+#include <QApplication>
+#include <QDebug>
+#include <QElapsedTimer>
+#include <QDir>
+#include <QImage>
+#include <QScreen>
+#include <QThread>
+#include <QWindow>
+#include <qt_windows.h>
+
+namespace {
+void settleWindows() {
+    QElapsedTimer timer;
+    timer.start();
+    while (timer.elapsed() < 300) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 20);
+        QThread::msleep(1);
+    }
+}
+
+QRect nativeClient(QWidget& widget) {
+    const HWND handle = reinterpret_cast<HWND>(widget.winId());
+    RECT client{};
+    POINT origin{};
+    if (!GetClientRect(handle, &client) || !ClientToScreen(handle, &origin)) {
+        return {};
+    }
+    return {origin.x, origin.y, client.right - client.left, client.bottom - client.top};
+}
+
+QImage captureDesktopRect(const QRect& bounds) {
+    if (bounds.isEmpty()) {
+        return {};
+    }
+    QImage result(bounds.size(), QImage::Format_RGB32);
+    const HDC desktop = GetDC(nullptr);
+    if (!desktop) {
+        return {};
+    }
+    const HDC memory = CreateCompatibleDC(desktop);
+    BITMAPINFO info{};
+    info.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    info.bmiHeader.biWidth = bounds.width();
+    info.bmiHeader.biHeight = -bounds.height();
+    info.bmiHeader.biPlanes = 1;
+    info.bmiHeader.biBitCount = 32;
+    info.bmiHeader.biCompression = BI_RGB;
+    void* pixels = nullptr;
+    const HBITMAP bitmap = CreateDIBSection(desktop, &info, DIB_RGB_COLORS, &pixels, nullptr, 0);
+    if (!desktop || !memory || !bitmap || !pixels) {
+        if (bitmap)
+            DeleteObject(bitmap);
+        if (memory)
+            DeleteDC(memory);
+        if (desktop)
+            ReleaseDC(nullptr, desktop);
+        return {};
+    }
+    const HGDIOBJ previous = SelectObject(memory, bitmap);
+    const bool copied = BitBlt(memory, 0, 0, bounds.width(), bounds.height(), desktop, bounds.x(),
+                               bounds.y(), SRCCOPY | CAPTUREBLT) != FALSE;
+    GdiFlush();
+    if (copied) {
+        result = QImage(static_cast<const uchar*>(pixels), bounds.width(), bounds.height(),
+                        QImage::Format_RGB32)
+                     .copy();
+    }
+    SelectObject(memory, previous);
+    DeleteObject(bitmap);
+    DeleteDC(memory);
+    ReleaseDC(nullptr, desktop);
+    return copied ? result : QImage();
+}
+
+bool renderedContentMatchesDesktop(ScreenRecordingToolbarWindow& toolbar, const char* phase) {
+    // Capture the compositor output FIRST. QWidget::render/grab can repaint a stale
+    // backing store and would otherwise hide the exact defect this test must detect.
+    const QImage actual = captureDesktopRect(nativeClient(toolbar));
+    const qreal dpr = toolbar.devicePixelRatioF();
+    QImage expected(QSize(qRound(toolbar.width() * dpr), qRound(toolbar.height() * dpr)),
+                    QImage::Format_ARGB32_Premultiplied);
+    expected.setDevicePixelRatio(dpr);
+    expected.fill(Qt::transparent);
+    toolbar.render(&expected);
+    const QString directory = QDir::current().filePath(QStringLiteral("toolbar-display-artifacts"));
+    if (!QDir().mkpath(directory) ||
+        !actual.save(directory + QLatin1Char('/') + QString::fromLatin1(phase) + "-desktop.png") ||
+        !expected.save(directory + QLatin1Char('/') + QString::fromLatin1(phase) + "-render.png")) {
+        qCritical() << "Could not save rendering evidence" << directory;
+        return false;
+    }
+    if (actual.size() != expected.size()) {
+        return false;
+    }
+    int opaquePixels = 0;
+    int differentPixels = 0;
+    for (int y = 0; y < expected.height(); ++y) {
+        for (int x = 0; x < expected.width(); ++x) {
+            const QColor reference = expected.pixelColor(x, y);
+            // Ignore transparent desktop/shadow pixels and blended rounded edges.
+            if (reference.alpha() != 255) {
+                continue;
+            }
+            ++opaquePixels;
+            const QColor observed = actual.pixelColor(x, y);
+            if (qMax(qAbs(reference.red() - observed.red()),
+                     qMax(qAbs(reference.green() - observed.green()),
+                          qAbs(reference.blue() - observed.blue()))) > 40) {
+                ++differentPixels;
+            }
+        }
+    }
+    qInfo() << phase << "opaque pixels" << opaquePixels << "different pixels" << differentPixels
+            << "evidence" << directory;
+    // Tolerate small font/animation differences, but not missing or enlarged rows.
+    return opaquePixels > 1000 && differentPixels <= opaquePixels / 50;
+}
+} // namespace
+
+// Invoked by the controller fixture, with its fake capture backend and isolated settings.
+// Real Windows surfaces are essential: offscreen QPA cannot exercise WM_DPICHANGED.
+int recordingToolbarAcrossNativeDisplays(bool startCapture) {
+    QScreen* displayA = nullptr;
+    QScreen* displayB = nullptr;
+    for (QScreen* a : QGuiApplication::screens()) {
+        const QRect aBounds = ScreenshotGeometryMapper::physicalRectForScreen(*a);
+        qInfo() << "Display" << a->name() << "DPR" << a->devicePixelRatio() << aBounds;
+        for (QScreen* b : QGuiApplication::screens()) {
+            const QRect bBounds = ScreenshotGeometryMapper::physicalRectForScreen(*b);
+            if (qAbs(a->devicePixelRatio() - 1.5) < 0.01 &&
+                qAbs(b->devicePixelRatio() - 1.0) < 0.01 && bBounds.right() + 1 == aBounds.left() &&
+                qMax(aBounds.top(), bBounds.top()) <= qMin(aBounds.bottom(), bBounds.bottom())) {
+                displayA = a;
+                displayB = b;
+            }
+        }
+    }
+    if (QGuiApplication::platformName() != QStringLiteral("windows") || !displayA || !displayB) {
+        qWarning()
+            << "SKIP: requires Windows with a 100% display B immediately left of a 150% display A";
+        return 77;
+    }
+
+    int failures = 0;
+    const auto check = [&](bool condition, const char* message) {
+        if (!condition) {
+            qCritical() << "FAIL:" << message;
+            ++failures;
+        }
+    };
+    ScreenRecordingController controller;
+    const QRect aBounds = ScreenshotGeometryMapper::physicalRectForScreen(*displayA);
+    const QRect bBounds = ScreenshotGeometryMapper::physicalRectForScreen(*displayB);
+    controller.open(QRect(aBounds.center() - QPoint(240, 160), QSize(480, 320)));
+    ScreenRecordingAreaWindow* area = nullptr;
+    ScreenRecordingToolbarWindow* toolbar = nullptr;
+    for (auto* widget : QApplication::topLevelWidgets()) {
+        if (auto* candidate = qobject_cast<ScreenRecordingAreaWindow*>(widget)) {
+            area = candidate;
+        }
+        if (auto* candidate = qobject_cast<ScreenRecordingToolbarWindow*>(widget)) {
+            toolbar = candidate;
+        }
+    }
+    if (!area || !toolbar) {
+        qCritical() << "FAIL: controller must create both recording windows";
+        return 1;
+    }
+    if (startCapture) {
+        controller.startRecording();
+    }
+    settleWindows();
+    check(controller.isRecording() == startCapture,
+          "source recording state must match the scenario");
+    auto* settings = toolbar->palette()->findChild<adqt::widgets::AdButton*>(
+        QStringLiteral("screenRecordingExportSettings"));
+    if (!settings) {
+        qCritical() << "FAIL: export settings control must exist";
+        return 1;
+    }
+    if (!toolbar->palette()->recordingExportSettingsVisible()) {
+        settings->click();
+    }
+    settleWindows();
+    check(area->inputMode() == ScreenRecordingAreaWindow::InputMode::RegionEditing,
+          "export settings must enable moving the active recording area");
+    check(toolbar->screen() == displayA &&
+              GetDpiForWindow(reinterpret_cast<HWND>(toolbar->winId())) == 144,
+          "source toolbar must begin on A at 144 DPI");
+    if (failures) {
+        return 1;
+    }
+
+    check(renderedContentMatchesDesktop(*toolbar, startCapture ? "active-source" : "source"),
+          "source toolbar compositor output must match its complete rendered content");
+    if (failures) {
+        return 1;
+    }
+
+    const HWND areaHandle = reinterpret_cast<HWND>(area->winId());
+    const QPoint hitPoint = area->physicalRegion().center();
+    check(SendMessageW(areaHandle, WM_NCHITTEST, 0, MAKELPARAM(hitPoint.x(), hitPoint.y())) ==
+              HTCAPTION,
+          "PREREQUISITE: recording area must accept dragging in the requested recording state");
+    if (failures) {
+        return 1;
+    }
+    int starts = 0;
+    int finishes = 0;
+    QObject::connect(area, &ScreenRecordingAreaWindow::regionInteractionStarted, area,
+                     [&]() { ++starts; });
+    QObject::connect(area, &ScreenRecordingAreaWindow::regionInteractionFinished, area,
+                     [&]() { ++finishes; });
+    // Replay the native move lifecycle without taking over the user's mouse. SetWindowPos
+    // crosses the real monitor boundary and lets Windows deliver the actual DPI change.
+    SendMessageW(areaHandle, WM_ENTERSIZEMOVE, 0, 0);
+    check(!toolbar->isVisible(), "toolbar must hide during the drag");
+    const QPoint destination = bBounds.center() - QPoint(240, 160);
+    check(SetWindowPos(areaHandle, nullptr, destination.x(), destination.y(), 0, 0,
+                       SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE) != FALSE,
+          "native recording area move must succeed");
+    settleWindows();
+    check(!toolbar->isVisible(), "toolbar must stay hidden until dragging ends");
+    SendMessageW(areaHandle, WM_EXITSIZEMOVE, 0, 0);
+
+    const auto verifyToolbar = [&](const char* phase) {
+        const QRect client = nativeClient(*toolbar);
+        const UINT dpi = GetDpiForWindow(reinterpret_cast<HWND>(toolbar->winId()));
+        const qreal dpr = toolbar->devicePixelRatioF();
+        const QRect localContent =
+            toolbar->occupiedContentRect().translated(toolbar->contentPosition() - toolbar->pos());
+        const QRect physicalContent(
+            client.topLeft() +
+                QPoint(qRound(localContent.x() * dpr), qRound(localContent.y() * dpr)),
+            QSize(qRound(localContent.width() * dpr), qRound(localContent.height() * dpr)));
+        qInfo() << phase << "native DPI" << dpi << "Qt DPR" << dpr << "client" << client << "widget"
+                << toolbar->size() << "hint" << toolbar->windowSizeHint() << "content"
+                << physicalContent << "area" << nativeClient(*area);
+        check(toolbar->isVisible(), "toolbar must reappear after release");
+        check(dpi == 96 && qAbs(dpr - 1.0) < 0.01 &&
+                  qAbs(toolbar->windowHandle()->devicePixelRatio() - 1.0) < 0.01 &&
+                  toolbar->screen() == displayB,
+              "native and Qt toolbar surfaces must adopt display B's 96 DPI");
+        check(client.size() ==
+                  QSize(qRound(toolbar->width() * dpr), qRound(toolbar->height() * dpr)),
+              "native client size must agree with the Qt window at target DPI");
+        check(toolbar->size() == toolbar->windowSizeHint() &&
+                  toolbar->rect().contains(toolbar->paletteHost()->geometry()) &&
+                  toolbar->rect().contains(localContent) && client.contains(physicalContent),
+              "all toolbar rows must fit inside the native window without clipping");
+        for (QWidget* child : toolbar->palette()->findChildren<QWidget*>()) {
+            if (!child->isVisibleTo(toolbar) || child->isWindow() || child->size().isEmpty()) {
+                continue;
+            }
+            const QRect bounds(child->mapTo(toolbar, QPoint()), child->size());
+            if (!toolbar->rect().contains(bounds)) {
+                qCritical() << "Clipped child" << child->metaObject()->className()
+                            << child->objectName() << bounds;
+                check(false, "visible toolbar controls must fit inside the window");
+            }
+        }
+        check(bBounds.contains(physicalContent), "all toolbar content must be inside display B");
+        // This central selection leaves room below. Placement is right-aligned to the
+        // area's outer frame with a four-DIP gap, clamped only at the display's left edge.
+        const QRect frame = nativeClient(*area);
+        const int expectedLeft = qMax(bBounds.left(), frame.right() + 1 - physicalContent.width());
+        check(qAbs(physicalContent.left() - expectedLeft) <= 1 &&
+                  qAbs(physicalContent.top() - (frame.bottom() + 1 + 4)) <= 1,
+              "toolbar must anchor below the final area with a 4-DIP gap and correct alignment");
+    };
+    check(starts == 1 && finishes == 1, "drag must have one balanced native interaction lifecycle");
+    check(area->screen() == displayB && bBounds.contains(area->physicalRegion()),
+          "recording area must finish completely on B");
+    verifyToolbar("Immediately after release");
+    settleWindows();
+    verifyToolbar("After queued DPI/layout events");
+    check(renderedContentMatchesDesktop(*toolbar,
+                                        startCapture ? "active-destination" : "destination"),
+          "destination compositor output must display all toolbar content at the correct scale");
+    check(controller.isRecording() == startCapture, "moving must preserve the recording state");
+    return failures == 0 ? 0 : 1;
+}

--- a/snow_shot/tests/screen_recording_toolbar_display_tests.md
+++ b/snow_shot/tests/screen_recording_toolbar_display_tests.md
@@ -1,0 +1,103 @@
+# Recording toolbar across displays
+
+Build the existing controller fixture:
+
+```powershell
+./scripts/build.ps1 -Preset windows-msvc-debug -Target snow-shot-screen-recording-controller-tests
+```
+
+Run only the two native display cases (the default test preset excludes interactive tests):
+
+```powershell
+ctest --test-dir build/windows-msvc-debug -C Debug -R '^snow-shot-screen-recording-toolbar-(ready-)?display-tests$' --output-on-failure
+```
+
+Requirements: a Windows desktop with display A at 150% and display B at 100%,
+with B's right physical edge adjacent to A's left physical edge and overlapping
+vertical bounds. Names and primary-display status do not matter. Missing topology
+returns CTest skip code 77; it does not count as a successful reproduction.
+
+Both cases use the real recording controller, area, toolbar, Qt Windows surfaces,
+and native DPI changes. The controller fixture substitutes the capture backend and
+uses temporary settings, so these tests do not capture desktop video or export media.
+
+- `snow-shot-screen-recording-toolbar-display-tests` starts capture on A first.
+- `snow-shot-screen-recording-toolbar-ready-display-tests` opens the recording tool
+  on A but leaves capture idle, isolating the toolbar transition in the currently
+  supported area-editing state.
+
+Each case opens Export Settings to enable region editing and verifies native
+`HTCAPTION` hit-testing before attempting movement. It replays `WM_ENTERSIZEMOVE`,
+`SetWindowPos`, and `WM_EXITSIZEMOVE` on the real area window. This deterministically
+exercises the native interaction handlers and Windows DPI transition without mouse
+input injection; it is not an end-to-end test of the operating system's mouse drag loop.
+
+Assertions cover the source 144-DPI window, balanced interaction notifications,
+toolbar hiding during movement and reappearance on release, target 96-DPI native and
+Qt surfaces, native/Qt client-size agreement, toolbar row and child-control bounds,
+containment on B, and alignment below the final area with a four-DIP gap. Target
+checks run immediately after release and again after queued layout events.
+
+The rendering assertion captures the real composited desktop pixels with GDI
+**before** calling `QWidget::render`, which could repaint and conceal a stale backing
+store. It then compares opaque pixels against a fresh render at the window's current
+DPI. Transparent background, shadows, and blended edges are excluded. RGB channel
+differences up to 40 are tolerated, and at most 2% of opaque reference pixels may
+exceed that threshold to accommodate minor font/animation differences. The same
+assertion must pass on A before the move, validating the capture and comparison path.
+This checks presented content against the widget's intended rendering; it is not a
+golden-image test for defects shared by both render paths.
+
+The test saves `source-desktop.png`, `source-render.png`, `destination-desktop.png`,
+and `destination-render.png` under
+`build/windows-msvc-debug/snow_shot/toolbar-display-artifacts/`. The active-capture
+case uses an `active-` filename prefix. Run on an unobstructed interactive desktop;
+another window covering the toolbar will also cause the compositor comparison to fail.
+
+The test does not invoke toolbar placement or repair methods after the move. The
+production controller must restore and position the toolbar itself. Failures remain
+ordinary failing assertions; neither test uses `WILL_FAIL`.
+
+Observed on 2026-09-09 with A `(0,0,3840,2160)` at 150% and B
+`(-3840,0,3840,2160)` at 100%:
+
+- Active capture fails the drag prerequisite. The current area implementation
+  permits region editing only while idle, even when its requested input mode is
+  `RegionEditing`. Post-drag toolbar checks cannot run in this state.
+- The idle/ready case **fails the destination rendering assertion**, reproducing the
+  enlarged content clipped at the right and bottom edges in the reported screenshot.
+  Native DPI is 96, Qt DPR is 1.0, and both the native client and Qt window are
+  1242 by 142 pixels; all geometry assertions pass. The source comparison has zero
+  mismatches among 139,233 opaque pixels. After the move, 32,681 of 62,932 opaque
+  reference pixels differ (about 52%). The desktop image is clipped while the fresh
+  target-DPI render shows the complete toolbar. The earlier geometry-only version
+  passed because it never inspected the pixels actually presented by Windows.
+
+## Fix and verification (2026-09-09)
+
+The ready case reproduced the same 32,681 mismatches before the fix. Diagnostic
+inspection found that the backing store still contained the 1863-by-213 source
+image even though the native client had become 1242 by 142. Updating the row widgets
+and invalidating their graphics effects did not repair it. A full repaint after
+the DPI transaction completed reduced destination mismatches to zero.
+
+The shared floating toolbar deliberately disables painting while reconciling its
+native frame and control scale. That ordering remains necessary to avoid painting
+against an intermediate frame. Qt's `QWidgetWindow::scheduleRepaint` skips hidden
+windows or windows with updates disabled, and a later `update()` can coalesce with
+already pending dirty state. The transaction now calls `repaint()` after restoring
+updates in its existing queued completion callback. This completes the backing-store
+repaint at the final scale; it requires no geometry adjustment, extra timer, surface
+recreation, or test-side repair.
+
+This is a local presentation-transaction defect in the shared floating toolbar.
+The ready native display regression passes with zero mismatches at both source
+and destination. The offscreen DPI frame test also covers a commit with unchanged
+logical dimensions, both while visible and when hidden then shown before completion.
+The related recording controller and screenshot capture-screen-switch tests pass.
+The active-capture case retains its separate, pre-existing drag prerequisite failure;
+the fix does not enable editing the capture area during recording.
+
+Geometry-only assertions missed the defect because all client and control bounds
+were correct. Keep the desktop comparison before `QWidget::render` as a regression
+constraint on actual presented pixels. Existing workspace changes were preserved.

--- a/snow_shot/tests/screenshot_floating_toolbar_drag_tests.cpp
+++ b/snow_shot/tests/screenshot_floating_toolbar_drag_tests.cpp
@@ -538,9 +538,9 @@ void recordingExportSettingsParticipateInNativeHitTesting() {
     require(exportButton != nullptr, "recording hit-test fixture should expose Export Settings");
     exportButton->click();
     settleQueuedRefreshes();
-    require(!palette->recordingExportSettingsVisible() &&
-                !palette->recordingExportSettingsPanel()->isVisible(),
-            "clicking active Export Settings should close the floating secondary toolbar");
+    require(palette->recordingExportSettingsVisible() &&
+                palette->recordingExportSettingsPanel()->isVisible(),
+            "clicking active Export Settings must retain the floating secondary toolbar");
     exportButton->click();
     settleQueuedRefreshes();
 
@@ -1256,6 +1256,35 @@ void dpiCommitReconcilesTheActualFrameBeforePainting() {
             "a DPI commit must reconcile the actual frame with the prepared content");
     require(monitor.painted && !monitor.clipped,
             "the first repaint after a DPI commit must contain the complete toolbar");
+}
+
+void dpiCommitPresentsContentWhenUpdatesResume() {
+    ScreenshotFloatingToolPaletteWindow window(testToolbarOptions());
+    window.prepareForDisplay();
+    window.show();
+    settleQueuedRefreshes();
+    auto* controller = window.findChild<adqt::widgets::AdDpiStableWindowController*>();
+    require(controller != nullptr, "toolbar must have a DPI controller");
+    ToolbarPaintExtentMonitor monitor(window);
+    for (const bool hiddenDuringCommit : {false, true}) {
+        if (hiddenDuringCommit) {
+            window.hide();
+        }
+        monitor.painted = false;
+        controller->scaleCommitCompleted(
+            adqt::widgets::AdControlScaleContext::fromDprs(window.devicePixelRatioF(),
+                                                           window.devicePixelRatioF()),
+            window.size());
+        if (hiddenDuringCommit) {
+            window.show();
+        }
+        // The frame is unchanged, as when logical toolbar dimensions stay the
+        // same across monitors. A resize must not be needed to refresh its pixels.
+        settleQueuedRefreshes();
+        require(window.updatesEnabled() && monitor.painted && !monitor.clipped,
+                "resuming updates after a DPI commit must present the complete toolbar "
+                "even when its logical frame is unchanged");
+    }
 }
 
 void reusedToolbarFitsOnFirstShowAcrossScreens() {
@@ -2174,6 +2203,7 @@ int main(int argc, char* argv[]) {
     try {
         if (app.arguments().contains(QStringLiteral("--dpi-frame-reconcile-only"))) {
             dpiCommitReconcilesTheActualFrameBeforePainting();
+            dpiCommitPresentsContentWhenUpdatesResume();
             return 0;
         }
         if (app.arguments().contains(QStringLiteral("--capture-screen-switch-only"))) {

--- a/snow_shot/tests/screenshot_tool_palette_tests.cpp
+++ b/snow_shot/tests/screenshot_tool_palette_tests.cpp
@@ -310,6 +310,7 @@ void recordingExportSettingsAndDrawingAvailabilityFollowSessionState() {
     options.showHighlightTool = true;
     options.showPenHighlightTool = true;
     options.showSpotlightTool = true;
+    options.showEraserTool = true;
     options.showFilterTool = true;
     options.showRecordingControls = true;
     options.recordingDrawingMode = true;
@@ -491,11 +492,11 @@ void recordingExportSettingsAndDrawingAvailabilityFollowSessionState() {
                      });
     exportButton->click();
     QCoreApplication::processEvents();
-    require(!exportPanel->isVisible() && !palette.recordingExportSettingsVisible() &&
-                !palette.activeToolForTests().has_value() && !exportVisible &&
-                exportVisibilityChanges == 1 &&
-                exportButton->buttonStyle() == adqt::widgets::AdButton::ButtonStyle::Text,
-            "clicking active Export Settings should deactivate it and notify the controller");
+    require(exportPanel->isVisible() && palette.recordingExportSettingsVisible() &&
+                !palette.activeToolForTests().has_value() && exportVisible &&
+                exportVisibilityChanges == 0 &&
+                exportButton->buttonStyle() == adqt::widgets::AdButton::ButtonStyle::Solid,
+            "clicking active Export Settings must be idempotent");
     exportButton->click();
     QCoreApplication::processEvents();
     require(exportPanel->isVisible() && palette.mainPanel()->geometry() == mainGeometry,
@@ -645,8 +646,8 @@ void recordingExportSettingsAndDrawingAvailabilityFollowSessionState() {
     QObject::connect(&palette, &ScreenshotToolPalette::selectRequested, &palette,
                      [&]() { ++selectRequests; });
     exportButton->click();
-    require(!exportPanel->isVisible() && !palette.activeToolForTests().has_value(),
-            "clicking active Export Settings should clear its selection");
+    require(exportPanel->isVisible() && !palette.activeToolForTests().has_value(),
+            "clicking active Export Settings must retain its selection");
     shapeButton->click();
     require(!exportPanel->isVisible() &&
                 palette.activeToolForTests() == ScreenshotToolPalette::Tool::Shape,
@@ -665,11 +666,11 @@ void recordingExportSettingsAndDrawingAvailabilityFollowSessionState() {
             "selecting an unavailable recording tool should leave the shared state unchanged");
     shapeButton->click();
     shapeButton->click();
-    require(!exportPanel->isVisible() && !palette.activeToolForTests().has_value() &&
+    require(exportPanel->isVisible() && !palette.activeToolForTests().has_value() &&
                 !palette.styleToolbarVisible() &&
                 shapeButton->buttonStyle() == adqt::widgets::AdButton::ButtonStyle::Text &&
                 selectRequests == 2,
-            "clicking the active drawing button should deactivate drawing and close its tools");
+            "clicking the active drawing button must switch to Export Settings");
     exportButton->click();
 
     int formatChanges = 0;
@@ -832,17 +833,17 @@ void recordingExportSettingsAndDrawingAvailabilityFollowSessionState() {
         verifyExportSettingsSelected(false);
         const int visibilityChangesBeforeClick = exportVisibilityChanges;
         exportButton->click();
-        require(!exportPanel->isVisible() && !palette.recordingExportSettingsVisible() &&
-                    !palette.activeToolForTests().has_value() && !exportVisible &&
-                    exportVisibilityChanges == visibilityChangesBeforeClick + 1,
-                "clicking active Export Settings during recording should deactivate it");
+        require(exportPanel->isVisible() && palette.recordingExportSettingsVisible() &&
+                    !palette.activeToolForTests().has_value() && exportVisible &&
+                    exportVisibilityChanges == visibilityChangesBeforeClick,
+                "clicking active Export Settings during recording must remain idempotent");
         shapeButton->click();
         const int selectRequestsBeforeClick = selectRequests;
         shapeButton->click();
         require(!palette.activeToolForTests().has_value() &&
-                    !palette.recordingExportSettingsVisible() && !palette.styleToolbarVisible() &&
+                    palette.recordingExportSettingsVisible() && !palette.styleToolbarVisible() &&
                     selectRequests == selectRequestsBeforeClick + 1,
-                "clicking active drawing during recording should return to pass-through mode");
+                "clicking active drawing during recording must return to Export Settings");
         shapeButton->click();
         require(palette.activeToolForTests() == ScreenshotToolPalette::Tool::Shape,
                 "a deactivated drawing tool should activate on the next click");
@@ -3867,10 +3868,16 @@ void groupedToolShortcutsToggleOnlyTheRequestedTool() {
     ScreenshotToolPalette recordingPalette(options);
     require(recordingPalette.activateDrawingShortcut(QStringLiteral("shape")) &&
                 recordingPalette.activateDrawingShortcut(QStringLiteral("shape")) &&
-                !recordingPalette.activeToolForTests().has_value(),
-            "recording shortcuts must toggle drawing off just like repeated button clicks");
+                !recordingPalette.activeToolForTests().has_value() &&
+                recordingPalette.recordingExportSettingsVisible(),
+            "repeated recording shortcuts must return to Export Settings");
+    recordingPalette.setActiveTool(Tool::Shape);
+    recordingPalette.setActiveTool(Tool::Shape);
+    require(recordingPalette.activeToolForTests() == Tool::Shape &&
+                !recordingPalette.recordingExportSettingsVisible(),
+            "programmatic recording tool synchronization must remain idempotent");
     require(!recordingPalette.activateDrawingShortcut(QStringLiteral("highlight")) &&
-                !recordingPalette.activeToolForTests().has_value(),
+                recordingPalette.activeToolForTests() == Tool::Shape,
             "unavailable recording shortcuts should leave the current tool unchanged");
 }
 


### PR DESCRIPTION
The original recording toolbar positioning fix was merged in #1096. This PR carries the follow-up changes on a fresh branch from current main: recording controls retain their placement and frame size across display/DPI changes, hide and restore around region interactions, and return to Export Settings when an active drawing tool is toggled off.

It preserves main's unified button and keyboard shortcut dispatch and includes regression coverage for recording geometry, controller behavior, shortcuts, frame reconciliation, and native hit-testing. This is the follow-up previously carried in #1102.

Validation:
- Built six related test targets with windows-msvc-debug: recording controller, recording shortcuts, recording geometry, recording area window, screenshot tool palette, and floating toolbar drag.
- All nine focused recording/toolbar tests passed on the identical source tree before moving the changes to this branch; verified the new branch tree exactly matches that validated tree.
- clang-format checks passed for the seven integration files; git diff --check passed.
- Full suite and interactive multi-display tests were not run. No separate clang-tidy run was performed.
