### PR TITLE
build(release): bump snow shot to 1.0.1-beta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 4.2)
 
 project(snow_apps VERSION 0.2.0 LANGUAGES CXX)
 
-set(SNOW_SHOT_VERSION "1.0.0-beta")
+set(SNOW_SHOT_VERSION "1.0.1-beta")
 if(NOT SNOW_SHOT_VERSION MATCHES "^([0-9]+\\.[0-9]+\\.[0-9]+)(-[0-9A-Za-z.-]+)?$")
     message(FATAL_ERROR "SNOW_SHOT_VERSION must be a semantic version such as 0.8.0-dev")
 endif()


### PR DESCRIPTION
Advance Snow Shot from 1.0.0-beta to 1.0.1-beta so application metadata, installers, archives, and the signed production update feed use the new release version. The single source of truth is SNOW_SHOT_VERSION in the root CMakeLists.txt.

Affected preset/targets: snow-shot-msvc-release; snow_shot, updater, and release packaging.

Validation: git diff --check passed; all 8 focused publisher tests passed; installer language tests passed for en_US, zh_CN, and zh_TW, including the CPack fixture. C++/Rust formatting and lint are not applicable to this CMake value-only change. No full test suite was run. The production build, package audits, and deployment will run from main after merge.
