### PR TITLE
fix(main-window): render interface text without hinting at fractional dpi

### DIFF
--- a/snow_shot/CMakeLists.txt
+++ b/snow_shot/CMakeLists.txt
@@ -1624,6 +1624,21 @@ if(SNOW_SHOT_BUILD_TESTS)
         ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Qt6::Core>"
     )
 
+    get_target_property(_main_window_font_sources snow-shot-about-page-tests SOURCES)
+    list(REMOVE_ITEM _main_window_font_sources tests/about_page_tests.cpp)
+    add_executable(snow-shot-main-window-font-tests
+        tests/main_window_font_tests.cpp
+        ${_main_window_font_sources}
+    )
+    target_link_libraries(snow-shot-main-window-font-tests PRIVATE
+        snow_shot_settings snow_shot_image_codec snow_shot_updates)
+    snow_shot_import_offscreen_platform(snow-shot-main-window-font-tests)
+    add_test(NAME snow-shot-main-window-font-tests COMMAND snow-shot-main-window-font-tests)
+    set_tests_properties(snow-shot-main-window-font-tests PROPERTIES
+        LABELS "unit"
+        ENVIRONMENT "${_SNOW_SHOT_OFFSCREEN_QPA_ENVIRONMENT};QT_SCALE_FACTOR=1.5"
+    )
+
     add_executable(snow-shot-settings-catalog-tests
         tests/settings_catalog_tests.cpp
     )

--- a/snow_shot/src/presentation/components/aboutpagewidget.cpp
+++ b/snow_shot/src/presentation/components/aboutpagewidget.cpp
@@ -170,6 +170,7 @@ class AboutArtwork final : public QWidget {
             svg.replace("fill=\"white\"", "fill=\"#263246\"");
         }
         m_renderer.load(svg);
+        m_renderer.setAspectRatioMode(Qt::KeepAspectRatio);
         setAccessibleName(QCoreApplication::translate(
             "AboutPageWidget", "Screenshot selection, annotation tools, and recognized text"));
         update();
@@ -595,10 +596,12 @@ AboutPageWidget::AboutPageWidget(QWidget* parent, UrlOpener urlOpener,
     connect(&themeManager, &styles::ThemeManager::themeChanged, this, &AboutPageWidget::applyTheme);
     applyTheme(m_ui->scheme);
     content->installEventFilter(this);
+    m_ui->container->scrollArea()->viewport()->installEventFilter(this);
 }
 
 AboutPageWidget::~AboutPageWidget() {
     m_ui->container->contentWidget()->removeEventFilter(this);
+    m_ui->container->scrollArea()->viewport()->removeEventFilter(this);
 }
 
 void AboutPageWidget::applyTheme(const styles::ThemeColorScheme& scheme) {
@@ -770,7 +773,6 @@ void AboutPageWidget::updateLayout() {
     const int artWidth =
         std::min(availableWidth,
                  qRound((wide ? std::clamp(width / scale * 0.29, 170.0, 218.0) : 210.0) * scale));
-    m_ui->artwork->setFixedSize(artWidth, qRound(artWidth * 340.0 / 460.0));
     const bool tiny = width < qRound(350 * scale);
     m_ui->identityLayout->setDirection(tiny ? QBoxLayout::TopToBottom : QBoxLayout::LeftToRight);
     m_ui->versionLayout->setDirection(wide ? QBoxLayout::LeftToRight : QBoxLayout::TopToBottom);
@@ -810,6 +812,23 @@ void AboutPageWidget::updateLayout() {
         }
         m_ui->resourceColumns = resourceColumns;
     }
+
+    int artHeight = qRound(artWidth * 340.0 / 460.0);
+    if (wide) {
+        // The scroll area uses the content's preferred height. Budget decorative artwork
+        // against the viewport so changes in text metrics do not force unnecessary scrolling.
+        const int bodyHeight = m_ui->body->hasHeightForWidth() ? m_ui->body->heightForWidth(width)
+                                                               : m_ui->body->sizeHint().height();
+        const int copyWidth = qMax(1, availableWidth - artWidth - m_ui->heroLayout->spacing());
+        const int copyHeight = m_ui->heroCopy->hasHeightForWidth()
+                                   ? m_ui->heroCopy->heightForWidth(copyWidth)
+                                   : m_ui->heroCopy->sizeHint().height();
+        const auto margins = m_ui->heroLayout->contentsMargins();
+        const int availableHeight = m_ui->container->scrollArea()->viewport()->height() -
+                                    bodyHeight - margins.top() - margins.bottom();
+        artHeight = qMin(artHeight, qMax(copyHeight, availableHeight));
+    }
+    m_ui->artwork->setFixedSize(artWidth, artHeight);
 }
 
 void AboutPageWidget::openProjectLink(const QUrl& url) {
@@ -895,7 +914,9 @@ void AboutPageWidget::changeEvent(QEvent* event) {
 }
 
 bool AboutPageWidget::eventFilter(QObject* watched, QEvent* event) {
-    if (watched == m_ui->container->contentWidget() && event->type() == QEvent::Resize) {
+    if ((watched == m_ui->container->contentWidget() ||
+         watched == m_ui->container->scrollArea()->viewport()) &&
+        event->type() == QEvent::Resize) {
         updateLayout();
     }
     return QWidget::eventFilter(watched, event);

--- a/snow_shot/src/presentation/mainwindow.cpp
+++ b/snow_shot/src/presentation/mainwindow.cpp
@@ -11,6 +11,7 @@
 #include "snow_shot/presentation/styles/themecolorscheme.h"
 
 #include <QEvent>
+#include <QFont>
 #include <QHBoxLayout>
 #include <QLinearGradient>
 #include <QMenuBar>
@@ -69,6 +70,12 @@ MainWindow::MainWindow(const snow_shot::presentation::settings::SettingsRegistry
     setMinimumSize(MAIN_WINDOW_MIN_WIDTH, MAIN_WINDOW_MIN_HEIGHT);
     setMouseTracking(true);
     setAttribute(Qt::WA_DeleteOnClose);
+
+    // DirectWrite's default hinting can retain grid fitting even at fractional DPI.
+    // Let all main-interface labels inherit smooth outlines before setting their sizes.
+    QFont interfaceFont = font();
+    interfaceFont.setHintingPreference(QFont::PreferNoHinting);
+    setFont(interfaceFont);
 
     menuBar()->hide();
     statusBar()->hide();

--- a/snow_shot/tests/main_window_font_tests.cpp
+++ b/snow_shot/tests/main_window_font_tests.cpp
@@ -1,0 +1,106 @@
+#include "snow_shot/presentation/components/actionrow.h"
+#include "snow_shot/presentation/components/contentcardwidget.h"
+#include "snow_shot/presentation/globalshortcutmanager.h"
+#include "snow_shot/presentation/mainwindow.h"
+#include "snow_shot/presentation/settings/settingsbackend.h"
+#include "snow_shot/presentation/settings/settingsruntimesession.h"
+#include "snow_shot/presentation/styles/thememanager.h"
+#include "snow_shot/storage/applicationstorage.h"
+
+#include <QApplication>
+#include <QDir>
+#include <QEvent>
+#include <QFontDatabase>
+#include <QLabel>
+#include <QTemporaryDir>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace settings = snow_shot::presentation::settings;
+namespace styles = snow_shot::presentation::styles;
+
+namespace {
+void require(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << message << '\n';
+        std::exit(EXIT_FAILURE);
+    }
+}
+
+void flushEvents() {
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    QCoreApplication::processEvents();
+}
+
+void requireSmoothTitles(QWidget& container, int expectedSize) {
+    int titleCount = 0;
+    for (const auto* label : container.findChildren<QLabel*>()) {
+        if (label->text().isEmpty() || label->font().pixelSize() != expectedSize) {
+            continue;
+        }
+        ++titleCount;
+        require(label->font().hintingPreference() == QFont::PreferNoHinting,
+                "large titles must inherit the main window's unhinted outline rendering");
+    }
+    require(titleCount > 0, "exercise actual large title labels, not just the window font");
+}
+
+void mainWindowTitlesKeepSmoothRendering() {
+    const QFont applicationFont = QApplication::font();
+    const auto& registry = settings::builtInSettingsRegistry();
+    snow_shot::presentation::GlobalShortcutManager shortcuts;
+    settings::BuiltInSettingsBackend backend(shortcuts);
+    settings::SettingsRuntimeSession session(registry, backend);
+    MainWindow window(registry, session);
+    window.show();
+    flushEvents();
+    auto* card = window.findChild<ContentCardWidget*>();
+    require(card != nullptr, "main window content exists");
+    const QString shortcutRoute = card->currentRoute();
+    require(!card->findChildren<ActionRow*>().isEmpty(), "default route contains shortcut buttons");
+
+    for (auto appearance : {styles::ThemeAppearance::Light, styles::ThemeAppearance::Dark}) {
+        styles::ThemeManager::instance().setThemeAppearance(appearance);
+        for (bool settingsPage : {false, true, false}) {
+            if (settingsPage) {
+                window.showInterfaceSettings();
+            } else {
+                card->setCurrentRoute(shortcutRoute);
+            }
+            flushEvents();
+            const int titleSize =
+                styles::ThemeManager::instance().themeColorScheme().metricAlias.fontSizeLG;
+            requireSmoothTitles(*card, titleSize);
+            QEvent languageChange(QEvent::LanguageChange);
+            QApplication::sendEvent(&window, &languageChange);
+            QEvent dpiChange(QEvent::DevicePixelRatioChange);
+            QApplication::sendEvent(&window, &dpiChange);
+            flushEvents();
+            requireSmoothTitles(*card, titleSize);
+        }
+    }
+    require(QApplication::font() == applicationFont,
+            "main window typography must not change the application font for other windows");
+}
+} // namespace
+
+int main(int argc, char** argv) {
+    QApplication application(argc, argv);
+#ifdef Q_OS_WIN
+    const QDir fonts(qEnvironmentVariable("WINDIR") + QStringLiteral("/Fonts"));
+    QFontDatabase::addApplicationFont(fonts.filePath(QStringLiteral("msyh.ttc")));
+    QFontDatabase::addApplicationFont(fonts.filePath(QStringLiteral("segoeui.ttf")));
+#endif
+    QCoreApplication::setOrganizationName(QStringLiteral("SnowShotTests"));
+    QCoreApplication::setApplicationName(QStringLiteral("main_window_font_tests"));
+    QTemporaryDir directory;
+    require(directory.isValid(), "isolated font test storage");
+    auto& storage = snow_shot::storage::ApplicationStorage::instance();
+    require(storage.initialize({directory.path(), directory.path(), 8000}).success,
+            "initialize isolated font test storage");
+    styles::ThemeManager::instance().initialize(application);
+    mainWindowTitlesKeepSmoothRendering();
+    storage.shutdown();
+    return 0;
+}


### PR DESCRIPTION
DirectWrite's default hinting keeps grid fitting at fractional scale factors, leaving large titles blurry. Set PreferNoHinting on the main window font so its labels inherit smooth outlines, and budget the about page artwork against the scroll viewport so the resulting text metrics do not force unnecessary scrolling.

Covered by the new snow-shot-main-window-font-tests unit test, which verifies titles keep unhinted rendering across theme, route, language, and dpr changes without leaking the font to the application.