### PR TITLE
feat(about): move update status and progress into the version card

### DIFF
--- a/snow_shot/i18n/snow_shot_en_US.ts
+++ b/snow_shot/i18n/snow_shot_en_US.ts
@@ -4,13 +4,13 @@
 <context>
     <name>AboutPageWidget</name>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="702"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="738"/>
         <source>About Snow Shot</source>
         <translation>About Snow Shot</translation>
     </message>
     <message>
         <location filename="../src/presentation/components/aboutpagewidget.cpp" line="139"/>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="703"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="739"/>
         <source>Snow Shot</source>
         <translation>Snow Shot</translation>
     </message>
@@ -21,7 +21,7 @@
     </message>
     <message>
         <location filename="../src/presentation/components/aboutpagewidget.cpp" line="143"/>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="715"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="751"/>
         <source>Text recognition</source>
         <translation>Text recognition</translation>
     </message>
@@ -31,241 +31,246 @@
         <translation>Turn pixels into usable text</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="173"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="174"/>
         <source>Screenshot selection, annotation tools, and recognized text</source>
         <translation>Screenshot selection, annotation tools, and recognized text</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="704"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="740"/>
         <source>Snow Shot logo</source>
         <translation>Snow Shot logo</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="705"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="741"/>
         <source>Free · Open source</source>
         <translation>Free · Open source</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="709"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="745"/>
         <source>Elegant screenshots</source>
         <translation>Elegant screenshots</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="710"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="746"/>
         <source>, excellent work.</source>
         <translation>, excellent work.</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="712"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="748"/>
         <source>Capture, annotate, recognize text, and record your screen,
 so every moment on screen can be expressed clearly and shared easily.</source>
         <translation>Capture, annotate, recognize text, and record your screen,
 so every moment on screen can be expressed clearly and shared easily.</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="714"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="750"/>
         <source>Screenshot capture</source>
         <translation>Screenshot capture</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="714"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="750"/>
         <source>Easy annotation</source>
         <translation>Easy annotation</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="715"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="751"/>
         <source>Screen recording</source>
         <translation>Screen recording</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="716"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="752"/>
         <source>Pin to screen</source>
         <translation>Pin to screen</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="716"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="752"/>
         <source>Screenshot history</source>
         <translation>Screenshot history</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="720"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="756"/>
         <source>Current version</source>
         <translation>Current version</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="721"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="757"/>
         <source>Unavailable</source>
         <translation>Unavailable</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="723"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="759"/>
         <source>Current version: %1</source>
         <translation>Current version: %1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="724"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="760"/>
         <source>Preview</source>
         <translation>Preview</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="729"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="765"/>
         <source>Copied</source>
         <translation>Copied</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="730"/>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="731"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="766"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="767"/>
         <source>Copy version number</source>
         <translation>Copy version number</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="732"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="768"/>
         <source>Copy the version number to the clipboard</source>
         <translation>Copy the version number to the clipboard</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="735"/>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="736"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="771"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="772"/>
         <source>Changelog</source>
         <translation>Changelog</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="738"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="774"/>
         <source>Official website</source>
         <translation>Official website</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="739"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="775"/>
         <source>Discover more features and ways to use it</source>
         <translation>Discover more features and ways to use it</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="741"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="777"/>
         <source>GitHub</source>
         <translation>GitHub</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="741"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="777"/>
         <source>View the source and improve it together</source>
         <translation>View the source and improve it together</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="743"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="779"/>
         <source>Feedback and suggestions</source>
         <translation>Feedback and suggestions</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="744"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="780"/>
         <source>Make the next experience better</source>
         <translation>Make the next experience better</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="746"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="782"/>
         <source>Built for daily work, and growing with the community.</source>
         <translation>Built for daily work, and growing with the community.</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="748"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="784"/>
         <source>%1 · %2</source>
         <translation>%1 · %2</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="755"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="791"/>
         <source>Could not open the link. Open %1 in your browser.</source>
         <translation>Could not open the link. Open %1 in your browser.</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="748"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="784"/>
         <source>GNU General Public License v3.0 or later</source>
         <translation>GNU General Public License v3.0 or later</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="749"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="785"/>
         <source>Free and open-source software. Distributed without any warranty.</source>
         <translation>Free and open-source software. Distributed without any warranty.</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="751"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="787"/>
         <source>Copyright © %1 %2</source>
         <translation>Copyright © %1 %2</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="752"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="788"/>
         <source>Snow Shot · Make expression clearer</source>
         <translation>Snow Shot · Make expression clearer</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="835"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="906"/>
         <source>Check for updates</source>
         <translation>Check for updates</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="838"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="909"/>
         <source>Automatic updates are unavailable for this copy.</source>
         <translation>Automatic updates are unavailable for this copy.</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="841"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="912"/>
         <source>Check for a newer version of Snow Shot.</source>
         <translation>Check for a newer version of Snow Shot.</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="842"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="913"/>
         <source>You are up to date.</source>
         <translation>You are up to date.</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="845"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="920"/>
         <source>Checking for updates…</source>
         <translation>Checking for updates…</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="848"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="924"/>
         <source>Update available: %1</source>
         <translation>Update available: %1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="849"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="925"/>
         <source>Download update</source>
         <translation>Download update</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="852"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="931"/>
         <source>Downloading %1 of %2 MB</source>
         <translation>Downloading %1 of %2 MB</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="857"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="934"/>
+        <source>Downloading update…</source>
+        <translation>Downloading update…</translation>
+    </message>
+    <message>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="939"/>
         <source>Verifying update…</source>
         <translation>Verifying update…</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="860"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="943"/>
         <source>Ready to install %1</source>
         <translation>Ready to install %1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="861"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="944"/>
         <source>Restart and update</source>
         <translation>Restart and update</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="864"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="950"/>
         <source>Preparing to restart and update…</source>
         <translation>Preparing to restart and update…</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="867"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="954"/>
         <source>Update failed: %1</source>
         <translation>Update failed: %1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="880"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="984"/>
         <source>Cancel download</source>
         <translation>Cancel download</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="885"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="993"/>
         <source>Update download progress</source>
         <translation>Update download progress</translation>
     </message>
@@ -988,7 +993,7 @@ so every moment on screen can be expressed clearly and shared easily.</translati
         <translation>Invalid recording shortcut</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="592"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="599"/>
         <source>Please press a key</source>
         <translation>Please press a key</translation>
     </message>
@@ -1013,7 +1018,7 @@ so every moment on screen can be expressed clearly and shared easily.</translati
         <translation>Add key config</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="587"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="594"/>
         <source>Unsupported key</source>
         <translation>Unsupported key</translation>
     </message>
@@ -6316,99 +6321,99 @@ so every moment on screen can be expressed clearly and shared easily.</translati
 <context>
     <name>ShortcutKeyRow</name>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="847"/>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="907"/>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="932"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="857"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="917"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="942"/>
         <source>Delay: %1 seconds</source>
         <translation>Delay: %1 seconds</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="974"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="984"/>
         <source>%1 (%2 s)</source>
         <translation>%1 (%2 s)</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1036"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1046"/>
         <source>Key configuration for &quot;%1&quot;</source>
         <translation>Key configuration for &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1042"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1052"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1043"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1053"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1104"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1114"/>
         <source>Unset</source>
         <translation>Unset</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1117"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1127"/>
         <source>Registered</source>
         <translation>Registered</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1120"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1130"/>
         <source>Partially registered</source>
         <translation>Partially registered</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1123"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1133"/>
         <source>Registration failed</source>
         <translation>Registration failed</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1126"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1136"/>
         <source>Not configured</source>
         <translation>Not configured</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1139"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1149"/>
         <source>Global shortcut status: %1</source>
         <translation>Global shortcut status: %1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1164"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1174"/>
         <source>already used by another application or action</source>
         <translation>already used by another application or action</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1167"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1177"/>
         <source>not supported as a Windows global shortcut</source>
         <translation>not supported as a Windows global shortcut</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1170"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1180"/>
         <source>global shortcuts are not supported on this platform</source>
         <translation>global shortcuts are not supported on this platform</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1174"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1184"/>
         <source>the system rejected this shortcut</source>
         <translation>the system rejected this shortcut</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1175"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1185"/>
         <source>the system rejected this shortcut (error %1)</source>
         <translation>the system rejected this shortcut (error %1)</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1179"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1189"/>
         <source>registration did not complete</source>
         <translation>registration did not complete</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1182"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1192"/>
         <source>%1: %2</source>
         <translation>%1: %2</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1187"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1197"/>
         <source>Some shortcuts are unavailable
 Available: %1
 Unavailable: %2</source>
@@ -6417,7 +6422,7 @@ Available: %1
 Unavailable: %2</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1192"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1202"/>
         <source>No configured shortcut is available
 %1
 Change the shortcut and try again</source>

--- a/snow_shot/i18n/snow_shot_zh_CN.ts
+++ b/snow_shot/i18n/snow_shot_zh_CN.ts
@@ -4,13 +4,13 @@
 <context>
     <name>AboutPageWidget</name>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="702"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="738"/>
         <source>About Snow Shot</source>
         <translation>关于 Snow Shot</translation>
     </message>
     <message>
         <location filename="../src/presentation/components/aboutpagewidget.cpp" line="139"/>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="703"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="739"/>
         <source>Snow Shot</source>
         <translation>Snow Shot</translation>
     </message>
@@ -21,7 +21,7 @@
     </message>
     <message>
         <location filename="../src/presentation/components/aboutpagewidget.cpp" line="143"/>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="715"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="751"/>
         <source>Text recognition</source>
         <translation>文字识别</translation>
     </message>
@@ -31,241 +31,246 @@
         <translation>把画面变成可用文字</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="173"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="174"/>
         <source>Screenshot selection, annotation tools, and recognized text</source>
         <translation>截图选区、标注工具与识别文字</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="704"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="740"/>
         <source>Snow Shot logo</source>
         <translation>Snow Shot 标志</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="705"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="741"/>
         <source>Free · Open source</source>
         <translation>自由 · 开源</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="709"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="745"/>
         <source>Elegant screenshots</source>
         <translation>优雅截图</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="710"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="746"/>
         <source>, excellent work.</source>
         <translation>，出色工作。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="712"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="748"/>
         <source>Capture, annotate, recognize text, and record your screen,
 so every moment on screen can be expressed clearly and shared easily.</source>
         <translation>截图、标注、文字识别和录屏，
 让屏幕上的每一刻都能清晰表达、轻松分享。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="714"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="750"/>
         <source>Screenshot capture</source>
         <translation>截图捕捉</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="714"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="750"/>
         <source>Easy annotation</source>
         <translation>轻松标注</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="715"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="751"/>
         <source>Screen recording</source>
         <translation>屏幕录制</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="716"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="752"/>
         <source>Pin to screen</source>
         <translation>固定到屏幕</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="716"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="752"/>
         <source>Screenshot history</source>
         <translation>截图历史</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="720"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="756"/>
         <source>Current version</source>
         <translation>当前版本</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="721"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="757"/>
         <source>Unavailable</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="723"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="759"/>
         <source>Current version: %1</source>
         <translation>当前版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="724"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="760"/>
         <source>Preview</source>
         <translation>预览版</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="729"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="765"/>
         <source>Copied</source>
         <translation>已复制</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="730"/>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="731"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="766"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="767"/>
         <source>Copy version number</source>
         <translation>复制版本号</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="732"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="768"/>
         <source>Copy the version number to the clipboard</source>
         <translation>将版本号复制到剪贴板</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="735"/>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="736"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="771"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="772"/>
         <source>Changelog</source>
         <translation>更新日志</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="738"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="774"/>
         <source>Official website</source>
         <translation>官方网站</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="739"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="775"/>
         <source>Discover more features and ways to use it</source>
         <translation>发现更多功能与使用方式</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="741"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="777"/>
         <source>GitHub</source>
         <translation>GitHub</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="741"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="777"/>
         <source>View the source and improve it together</source>
         <translation>查看源码，一起改进</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="743"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="779"/>
         <source>Feedback and suggestions</source>
         <translation>反馈与建议</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="744"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="780"/>
         <source>Make the next experience better</source>
         <translation>让下一次体验更好</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="746"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="782"/>
         <source>Built for daily work, and growing with the community.</source>
         <translation>为日常工作打造，也在社区中持续成长。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="748"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="784"/>
         <source>%1 · %2</source>
         <translation>%1 · %2</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="755"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="791"/>
         <source>Could not open the link. Open %1 in your browser.</source>
         <translation>无法打开链接。请在浏览器中打开 %1。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="748"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="784"/>
         <source>GNU General Public License v3.0 or later</source>
         <translation>GNU 通用公共许可证 v3.0 或更高版本</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="749"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="785"/>
         <source>Free and open-source software. Distributed without any warranty.</source>
         <translation>自由开源软件，不提供任何担保。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="751"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="787"/>
         <source>Copyright © %1 %2</source>
         <translation>版权所有 © %1 %2</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="752"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="788"/>
         <source>Snow Shot · Make expression clearer</source>
         <translation>Snow Shot · 让表达更清晰</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="835"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="906"/>
         <source>Check for updates</source>
         <translation>检查更新</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="838"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="909"/>
         <source>Automatic updates are unavailable for this copy.</source>
         <translation>此副本无法使用自动更新。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="841"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="912"/>
         <source>Check for a newer version of Snow Shot.</source>
         <translation>检查是否有新版 Snow Shot。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="842"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="913"/>
         <source>You are up to date.</source>
         <translation>当前已是最新版本。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="845"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="920"/>
         <source>Checking for updates…</source>
         <translation>正在检查更新…</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="848"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="924"/>
         <source>Update available: %1</source>
         <translation>发现新版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="849"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="925"/>
         <source>Download update</source>
         <translation>下载更新</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="852"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="931"/>
         <source>Downloading %1 of %2 MB</source>
         <translation>正在下载：%1 / %2 MB</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="857"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="934"/>
+        <source>Downloading update…</source>
+        <translation>正在下载更新…</translation>
+    </message>
+    <message>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="939"/>
         <source>Verifying update…</source>
         <translation>正在验证更新…</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="860"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="943"/>
         <source>Ready to install %1</source>
         <translation>已准备好安装 %1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="861"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="944"/>
         <source>Restart and update</source>
         <translation>重启并更新</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="864"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="950"/>
         <source>Preparing to restart and update…</source>
         <translation>正在准备重启并更新…</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="867"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="954"/>
         <source>Update failed: %1</source>
         <translation>更新失败：%1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="880"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="984"/>
         <source>Cancel download</source>
         <translation>取消下载</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="885"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="993"/>
         <source>Update download progress</source>
         <translation>更新下载进度</translation>
     </message>
@@ -988,7 +993,7 @@ so every moment on screen can be expressed clearly and shared easily.</source>
         <translation>无效的录屏快捷键</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="592"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="599"/>
         <source>Please press a key</source>
         <translation>请按下按键</translation>
     </message>
@@ -1013,7 +1018,7 @@ so every moment on screen can be expressed clearly and shared easily.</source>
         <translation>添加按键配置</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="587"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="594"/>
         <source>Unsupported key</source>
         <translation>不支持的按键</translation>
     </message>
@@ -6315,99 +6320,99 @@ so every moment on screen can be expressed clearly and shared easily.</source>
 <context>
     <name>ShortcutKeyRow</name>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="847"/>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="907"/>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="932"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="857"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="917"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="942"/>
         <source>Delay: %1 seconds</source>
         <translation>延时：%1 秒</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="974"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="984"/>
         <source>%1 (%2 s)</source>
         <translation>%1（%2 秒）</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1036"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1046"/>
         <source>Key configuration for &quot;%1&quot;</source>
         <translation>“%1”的按键配置</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1042"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1052"/>
         <source>OK</source>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1043"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1053"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1104"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1114"/>
         <source>Unset</source>
         <translation>未设置</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1117"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1127"/>
         <source>Registered</source>
         <translation>已注册</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1120"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1130"/>
         <source>Partially registered</source>
         <translation>部分注册</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1123"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1133"/>
         <source>Registration failed</source>
         <translation>注册失败</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1126"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1136"/>
         <source>Not configured</source>
         <translation>未配置</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1139"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1149"/>
         <source>Global shortcut status: %1</source>
         <translation>全局快捷键状态：%1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1164"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1174"/>
         <source>already used by another application or action</source>
         <translation>已被其他应用程序或操作使用</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1167"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1177"/>
         <source>not supported as a Windows global shortcut</source>
         <translation>不支持作为 Windows 全局快捷键</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1170"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1180"/>
         <source>global shortcuts are not supported on this platform</source>
         <translation>此平台不支持全局快捷键</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1174"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1184"/>
         <source>the system rejected this shortcut</source>
         <translation>系统拒绝了此快捷键</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1175"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1185"/>
         <source>the system rejected this shortcut (error %1)</source>
         <translation>系统拒绝了此快捷键（错误 %1）</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1179"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1189"/>
         <source>registration did not complete</source>
         <translation>注册未完成</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1182"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1192"/>
         <source>%1: %2</source>
         <translation>%1：%2</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1187"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1197"/>
         <source>Some shortcuts are unavailable
 Available: %1
 Unavailable: %2</source>
@@ -6416,7 +6421,7 @@ Unavailable: %2</source>
 不可用：%2</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1192"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1202"/>
         <source>No configured shortcut is available
 %1
 Change the shortcut and try again</source>

--- a/snow_shot/i18n/snow_shot_zh_TW.ts
+++ b/snow_shot/i18n/snow_shot_zh_TW.ts
@@ -4,13 +4,13 @@
 <context>
     <name>AboutPageWidget</name>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="702"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="738"/>
         <source>About Snow Shot</source>
         <translation>關於 Snow Shot</translation>
     </message>
     <message>
         <location filename="../src/presentation/components/aboutpagewidget.cpp" line="139"/>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="703"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="739"/>
         <source>Snow Shot</source>
         <translation>Snow Shot</translation>
     </message>
@@ -21,7 +21,7 @@
     </message>
     <message>
         <location filename="../src/presentation/components/aboutpagewidget.cpp" line="143"/>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="715"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="751"/>
         <source>Text recognition</source>
         <translation>文字辨識</translation>
     </message>
@@ -31,241 +31,246 @@
         <translation>把畫面變成可用文字</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="173"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="174"/>
         <source>Screenshot selection, annotation tools, and recognized text</source>
         <translation>截圖選取範圍、標註工具與辨識文字</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="704"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="740"/>
         <source>Snow Shot logo</source>
         <translation>Snow Shot 標誌</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="705"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="741"/>
         <source>Free · Open source</source>
         <translation>自由 · 開源</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="709"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="745"/>
         <source>Elegant screenshots</source>
         <translation>優雅截圖</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="710"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="746"/>
         <source>, excellent work.</source>
         <translation>，出色工作。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="712"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="748"/>
         <source>Capture, annotate, recognize text, and record your screen,
 so every moment on screen can be expressed clearly and shared easily.</source>
         <translation>截圖、標註、文字辨識和螢幕錄影，
 讓螢幕上的每一刻都能清晰表達、輕鬆分享。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="714"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="750"/>
         <source>Screenshot capture</source>
         <translation>截圖擷取</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="714"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="750"/>
         <source>Easy annotation</source>
         <translation>輕鬆標註</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="715"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="751"/>
         <source>Screen recording</source>
         <translation>螢幕錄影</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="716"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="752"/>
         <source>Pin to screen</source>
         <translation>固定到螢幕</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="716"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="752"/>
         <source>Screenshot history</source>
         <translation>截圖歷史</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="720"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="756"/>
         <source>Current version</source>
         <translation>目前版本</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="721"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="757"/>
         <source>Unavailable</source>
         <translation>無法使用</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="723"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="759"/>
         <source>Current version: %1</source>
         <translation>目前版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="724"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="760"/>
         <source>Preview</source>
         <translation>預覽版</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="729"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="765"/>
         <source>Copied</source>
         <translation>已複製</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="730"/>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="731"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="766"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="767"/>
         <source>Copy version number</source>
         <translation>複製版本號碼</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="732"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="768"/>
         <source>Copy the version number to the clipboard</source>
         <translation>將版本號碼複製到剪貼簿</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="735"/>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="736"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="771"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="772"/>
         <source>Changelog</source>
         <translation>更新日誌</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="738"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="774"/>
         <source>Official website</source>
         <translation>官方網站</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="739"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="775"/>
         <source>Discover more features and ways to use it</source>
         <translation>探索更多功能與使用方式</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="741"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="777"/>
         <source>GitHub</source>
         <translation>GitHub</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="741"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="777"/>
         <source>View the source and improve it together</source>
         <translation>查看原始碼，一起改進</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="743"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="779"/>
         <source>Feedback and suggestions</source>
         <translation>回饋與建議</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="744"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="780"/>
         <source>Make the next experience better</source>
         <translation>讓下一次體驗更好</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="746"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="782"/>
         <source>Built for daily work, and growing with the community.</source>
         <translation>為日常工作打造，也在社群中持續成長。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="748"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="784"/>
         <source>%1 · %2</source>
         <translation>%1 · %2</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="755"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="791"/>
         <source>Could not open the link. Open %1 in your browser.</source>
         <translation>無法開啟連結。請在瀏覽器中開啟 %1。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="748"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="784"/>
         <source>GNU General Public License v3.0 or later</source>
         <translation>GNU 通用公共授權條款 v3.0 或更新版本</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="749"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="785"/>
         <source>Free and open-source software. Distributed without any warranty.</source>
         <translation>自由開源軟體，不提供任何擔保。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="751"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="787"/>
         <source>Copyright © %1 %2</source>
         <translation>著作權所有 © %1 %2</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="752"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="788"/>
         <source>Snow Shot · Make expression clearer</source>
         <translation>Snow Shot · 讓表達更清晰</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="835"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="906"/>
         <source>Check for updates</source>
         <translation>檢查更新</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="838"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="909"/>
         <source>Automatic updates are unavailable for this copy.</source>
         <translation>此副本無法使用自動更新。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="841"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="912"/>
         <source>Check for a newer version of Snow Shot.</source>
         <translation>檢查是否有新版 Snow Shot。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="842"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="913"/>
         <source>You are up to date.</source>
         <translation>目前已是最新版本。</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="845"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="920"/>
         <source>Checking for updates…</source>
         <translation>正在檢查更新…</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="848"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="924"/>
         <source>Update available: %1</source>
         <translation>發現新版本：%1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="849"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="925"/>
         <source>Download update</source>
         <translation>下載更新</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="852"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="931"/>
         <source>Downloading %1 of %2 MB</source>
         <translation>正在下載：%1 / %2 MB</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="857"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="934"/>
+        <source>Downloading update…</source>
+        <translation>正在下載更新…</translation>
+    </message>
+    <message>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="939"/>
         <source>Verifying update…</source>
         <translation>正在驗證更新…</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="860"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="943"/>
         <source>Ready to install %1</source>
         <translation>已準備好安裝 %1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="861"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="944"/>
         <source>Restart and update</source>
         <translation>重新啟動並更新</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="864"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="950"/>
         <source>Preparing to restart and update…</source>
         <translation>正在準備重新啟動並更新…</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="867"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="954"/>
         <source>Update failed: %1</source>
         <translation>更新失敗：%1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="880"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="984"/>
         <source>Cancel download</source>
         <translation>取消下載</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="885"/>
+        <location filename="../src/presentation/components/aboutpagewidget.cpp" line="993"/>
         <source>Update download progress</source>
         <translation>更新下載進度</translation>
     </message>
@@ -988,7 +993,7 @@ so every moment on screen can be expressed clearly and shared easily.</source>
         <translation>無效的錄影快捷鍵</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="592"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="599"/>
         <source>Please press a key</source>
         <translation>請按下按鍵</translation>
     </message>
@@ -1013,7 +1018,7 @@ so every moment on screen can be expressed clearly and shared easily.</source>
         <translation>新增按鍵設定</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="587"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="594"/>
         <source>Unsupported key</source>
         <translation>不支援的按鍵</translation>
     </message>
@@ -6315,99 +6320,99 @@ so every moment on screen can be expressed clearly and shared easily.</source>
 <context>
     <name>ShortcutKeyRow</name>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="847"/>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="907"/>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="932"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="857"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="917"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="942"/>
         <source>Delay: %1 seconds</source>
         <translation>延遲：%1 秒</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="974"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="984"/>
         <source>%1 (%2 s)</source>
         <translation>%1（%2 秒）</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1036"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1046"/>
         <source>Key configuration for &quot;%1&quot;</source>
         <translation>「%1」的按鍵設定</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1042"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1052"/>
         <source>OK</source>
         <translation>確定</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1043"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1053"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1104"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1114"/>
         <source>Unset</source>
         <translation>未設定</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1117"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1127"/>
         <source>Registered</source>
         <translation>已註冊</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1120"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1130"/>
         <source>Partially registered</source>
         <translation>部分已註冊</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1123"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1133"/>
         <source>Registration failed</source>
         <translation>註冊失敗</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1126"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1136"/>
         <source>Not configured</source>
         <translation>未設定</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1139"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1149"/>
         <source>Global shortcut status: %1</source>
         <translation>全域快速鍵狀態：%1</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1164"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1174"/>
         <source>already used by another application or action</source>
         <translation>已被其他應用程式或動作使用</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1167"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1177"/>
         <source>not supported as a Windows global shortcut</source>
         <translation>不支援作為 Windows 全域快速鍵</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1170"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1180"/>
         <source>global shortcuts are not supported on this platform</source>
         <translation>此平台不支援全域快速鍵</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1174"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1184"/>
         <source>the system rejected this shortcut</source>
         <translation>系統拒絕了此快速鍵</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1175"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1185"/>
         <source>the system rejected this shortcut (error %1)</source>
         <translation>系統拒絕了此快速鍵（錯誤 %1）</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1179"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1189"/>
         <source>registration did not complete</source>
         <translation>註冊未完成</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1182"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1192"/>
         <source>%1: %2</source>
         <translation>%1：%2</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1187"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1197"/>
         <source>Some shortcuts are unavailable
 Available: %1
 Unavailable: %2</source>
@@ -6416,7 +6421,7 @@ Unavailable: %2</source>
 不可用：%2</translation>
     </message>
     <message>
-        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1192"/>
+        <location filename="../src/presentation/components/shortcutkeyrow.cpp" line="1202"/>
         <source>No configured shortcut is available
 %1
 Change the shortcut and try again</source>

--- a/snow_shot/src/presentation/components/aboutpagewidget.cpp
+++ b/snow_shot/src/presentation/components/aboutpagewidget.cpp
@@ -349,6 +349,7 @@ struct AboutPageWidget::Ui {
         custom::outlined::PinToScreen(),       outlined::History()};
     QFrame* featureDivider = nullptr;
     QFrame* versionPanel = nullptr;
+    QVBoxLayout* versionPanelLayout = nullptr;
     QBoxLayout* versionLayout = nullptr;
     QLabel* versionCaption = nullptr;
     QLabel* versionValue = nullptr;
@@ -359,6 +360,9 @@ struct AboutPageWidget::Ui {
     QTimer* copyFeedbackTimer = nullptr;
     snow_shot::update::UpdateService* updates = nullptr;
     QLabel* updateStatus = nullptr;
+    QLabel* updateIcon = nullptr;
+    QFrame* updateDivider = nullptr;
+    QBoxLayout* updateLayout = nullptr;
     QProgressBar* updateProgress = nullptr;
     AdButton* updateAction = nullptr;
     AdButton* updateCancel = nullptr;
@@ -458,7 +462,9 @@ AboutPageWidget::AboutPageWidget(QWidget* parent, UrlOpener urlOpener,
 
     m_ui->versionPanel = new QFrame(m_ui->body);
     m_ui->versionPanel->setObjectName(QStringLiteral("aboutVersionPanel"));
-    m_ui->versionLayout = new QBoxLayout(QBoxLayout::LeftToRight, m_ui->versionPanel);
+    m_ui->versionPanelLayout = new QVBoxLayout(m_ui->versionPanel);
+    m_ui->versionLayout = new QBoxLayout(QBoxLayout::LeftToRight);
+    m_ui->versionPanelLayout->addLayout(m_ui->versionLayout);
     auto* versionText = new QVBoxLayout;
     versionText->setSpacing(2);
     m_ui->versionCaption = aboutLabel(QStringLiteral("aboutVersionCaption"), m_ui->versionPanel);
@@ -496,23 +502,37 @@ AboutPageWidget::AboutPageWidget(QWidget* parent, UrlOpener urlOpener,
     m_ui->updates =
         updates != nullptr ? updates : qApp->findChild<snow_shot::update::UpdateService*>();
     if (m_ui->updates != nullptr) {
-        m_ui->updateStatus = aboutLabel(QStringLiteral("aboutUpdateStatus"), m_ui->body);
-        m_ui->bodyLayout->addWidget(m_ui->updateStatus);
-        m_ui->updateProgress = new QProgressBar(m_ui->body);
+        m_ui->updateDivider = aboutDivider(m_ui->versionPanel);
+        m_ui->updateDivider->setObjectName(QStringLiteral("aboutUpdateDivider"));
+        m_ui->versionPanelLayout->addWidget(m_ui->updateDivider);
+        m_ui->updateLayout = new QBoxLayout(QBoxLayout::LeftToRight);
+        auto* statusRow = new QHBoxLayout;
+        m_ui->updateIcon = new QLabel(m_ui->versionPanel);
+        m_ui->updateIcon->setObjectName(QStringLiteral("aboutUpdateIcon"));
+        statusRow->addWidget(m_ui->updateIcon, 0, Qt::AlignVCenter);
+        m_ui->updateStatus = aboutLabel(QStringLiteral("aboutUpdateStatus"), m_ui->versionPanel);
+        statusRow->addWidget(m_ui->updateStatus, 1);
+        m_ui->updateLayout->addLayout(statusRow, 1);
+        m_ui->versionPanelLayout->addLayout(m_ui->updateLayout);
+        m_ui->updateProgress = new QProgressBar(m_ui->versionPanel);
         m_ui->updateProgress->setObjectName(QStringLiteral("aboutUpdateProgress"));
         m_ui->updateProgress->setRange(0, 1000);
         m_ui->updateProgress->setTextVisible(false);
-        m_ui->bodyLayout->addWidget(m_ui->updateProgress);
+        m_ui->versionPanelLayout->addWidget(m_ui->updateProgress);
         m_ui->updateActions = new QBoxLayout(QBoxLayout::LeftToRight);
         auto* actions = m_ui->updateActions;
-        m_ui->updateAction = new adqt::widgets::AdButton(m_ui->body);
+        m_ui->updateAction = new AdButton(m_ui->versionPanel);
         m_ui->updateAction->setObjectName(QStringLiteral("aboutUpdateAction"));
-        m_ui->updateCancel = new adqt::widgets::AdButton(m_ui->body);
+        m_ui->updateCancel = new AdButton(m_ui->versionPanel);
         m_ui->updateCancel->setObjectName(QStringLiteral("aboutUpdateCancel"));
         actions->addWidget(m_ui->updateAction);
         actions->addWidget(m_ui->updateCancel);
-        actions->addStretch();
-        m_ui->bodyLayout->addLayout(actions);
+        for (auto* button : {m_ui->updateAction, m_ui->updateCancel}) {
+            button->setButtonStyle(AdButton::ButtonStyle::Outline);
+            button->setSizeClass(AdButton::SizeClass::Small);
+            button->setFocusPolicy(Qt::StrongFocus);
+        }
+        m_ui->updateLayout->addLayout(actions);
         connect(m_ui->updates, &snow_shot::update::UpdateService::statusChanged, this,
                 &AboutPageWidget::refreshUpdateStatus);
         connect(m_ui->updateCancel, &adqt::widgets::AdButton::clicked, m_ui->updates,
@@ -634,14 +654,27 @@ void AboutPageWidget::applyTheme(const styles::ThemeColorScheme& scheme) {
         separator->setPalette(palette);
         separator->setAutoFillBackground(true);
     }
-    m_ui->versionLayout->setContentsMargins(metric.padding, metric.paddingXS, metric.padding,
-                                            metric.paddingXS);
+    m_ui->versionPanelLayout->setContentsMargins(metric.padding, metric.paddingXS, metric.padding,
+                                                 metric.paddingXXS);
+    m_ui->versionPanelLayout->setSpacing(metric.paddingXXS);
     m_ui->versionLayout->setSpacing(metric.paddingSM);
     m_ui->versionActions->setSpacing(metric.paddingXS);
     if (m_ui->updateStatus != nullptr) {
-        styleAboutLabel(m_ui->updateStatus, metric.fontSizeSM, QFont::Normal,
-                        colors.colorTextSecondary);
+        m_ui->updateDivider->setStyleSheet(
+            QStringLiteral("QFrame#aboutUpdateDivider { background-color: %1; border: none; }")
+                .arg(colors.colorBorderSecondary.name(QColor::HexArgb)));
+        m_ui->updateLayout->setSpacing(metric.paddingSM);
+        m_ui->updateLayout->itemAt(0)->layout()->setSpacing(metric.paddingXS);
         m_ui->updateActions->setSpacing(metric.paddingXS);
+        const int progressHeight = qMax(4, metric.paddingXXS);
+        m_ui->updateProgress->setFixedHeight(progressHeight);
+        m_ui->updateProgress->setStyleSheet(
+            QStringLiteral("QProgressBar#aboutUpdateProgress { background: %1; border: none; "
+                           "border-radius: %3px; } QProgressBar#aboutUpdateProgress::chunk { "
+                           "background: %2; border-radius: %3px; }")
+                .arg(colors.colorFillSecondary.name(QColor::HexArgb),
+                     colors.colorPrimary.name(QColor::HexArgb))
+                .arg(progressHeight / 2));
     }
     const QColor versionBackground =
         blendAboutColor(colors.colorBgLayout, colors.colorBgContainer, 0.8);
@@ -776,8 +809,23 @@ void AboutPageWidget::updateLayout() {
     const bool tiny = width < qRound(350 * scale);
     m_ui->identityLayout->setDirection(tiny ? QBoxLayout::TopToBottom : QBoxLayout::LeftToRight);
     m_ui->versionLayout->setDirection(wide ? QBoxLayout::LeftToRight : QBoxLayout::TopToBottom);
-    m_ui->versionActions->setDirection(tiny ? QBoxLayout::TopToBottom : QBoxLayout::LeftToRight);
+    const int versionWidth = width - m_ui->bodyLayout->contentsMargins().left() -
+                             m_ui->bodyLayout->contentsMargins().right() -
+                             m_ui->versionPanelLayout->contentsMargins().left() -
+                             m_ui->versionPanelLayout->contentsMargins().right();
+    const int versionActionsWidth = m_ui->releaseNotes->sizeHint().width() +
+                                    m_ui->copyButton->sizeHint().width() +
+                                    m_ui->versionActions->spacing();
+    // An oversized minimum width makes Qt calculate wrapped text heights at the wrong width.
+    // Stack the version actions before they can force the shared card wider than its viewport.
+    m_ui->versionActions->setDirection(tiny || versionWidth < versionActionsWidth
+                                           ? QBoxLayout::TopToBottom
+                                           : QBoxLayout::LeftToRight);
     if (m_ui->updateActions != nullptr) {
+        const bool stackUpdate =
+            tiny || versionWidth < m_ui->updateActions->sizeHint().width() + qRound(220 * scale);
+        m_ui->updateLayout->setDirection(stackUpdate ? QBoxLayout::TopToBottom
+                                                     : QBoxLayout::LeftToRight);
         m_ui->updateActions->setDirection(tiny ? QBoxLayout::TopToBottom : QBoxLayout::LeftToRight);
     }
     m_ui->footerLayout->setDirection(wide ? QBoxLayout::LeftToRight : QBoxLayout::TopToBottom);
@@ -850,6 +898,10 @@ void AboutPageWidget::refreshUpdateStatus() {
     }
     using snow_shot::update::UpdateState;
     const auto& status = m_ui->updates->status();
+    const auto& colors = m_ui->scheme.map;
+    QColor statusColor = colors.colorTextSecondary;
+    auto statusIcon = outlined::InfoCircle();
+    auto actionIcon = outlined::Sync();
     QString text;
     QString action = tr("Check for updates");
     switch (status.state) {
@@ -859,49 +911,87 @@ void AboutPageWidget::refreshUpdateStatus() {
     case UpdateState::Idle:
         text = status.version.isEmpty() ? tr("Check for a newer version of Snow Shot.")
                                         : tr("You are up to date.");
+        if (!status.version.isEmpty()) {
+            statusIcon = outlined::CheckCircle();
+            statusColor = colors.colorSuccessText;
+        }
         break;
     case UpdateState::Checking:
         text = tr("Checking for updates…");
+        statusIcon = outlined::Sync();
         break;
     case UpdateState::Available:
         text = tr("Update available: %1").arg(status.version);
         action = tr("Download update");
+        statusIcon = outlined::CloudDownload();
+        actionIcon = outlined::Download();
+        statusColor = colors.colorInfoText;
         break;
     case UpdateState::Downloading:
-        text = tr("Downloading %1 of %2 MB")
-                   .arg(status.received / 1048576)
-                   .arg(status.total / 1048576);
+        text = status.total > 0 ? tr("Downloading %1 of %2 MB")
+                                      .arg(status.received / 1048576)
+                                      .arg(status.total / 1048576)
+                                : tr("Downloading update…");
+        statusIcon = outlined::CloudDownload();
+        statusColor = colors.colorInfoText;
         break;
     case UpdateState::Verifying:
         text = tr("Verifying update…");
+        statusIcon = outlined::SafetyCertificate();
         break;
     case UpdateState::Ready:
         text = tr("Ready to install %1").arg(status.version);
         action = tr("Restart and update");
+        statusIcon = outlined::CheckCircle();
+        actionIcon = outlined::Reload();
+        statusColor = colors.colorSuccessText;
         break;
     case UpdateState::Applying:
         text = tr("Preparing to restart and update…");
+        statusIcon = outlined::Sync();
         break;
     case UpdateState::Failed:
         text = tr("Update failed: %1").arg(status.error);
+        statusIcon = outlined::ExclamationCircle();
+        statusColor = colors.colorErrorText;
         break;
     }
     if (!status.error.isEmpty() && status.state == UpdateState::Ready) {
         text += u'\n' + status.error;
+        statusIcon = outlined::ExclamationCircle();
+        statusColor = colors.colorWarningText;
     }
+    styleAboutLabel(m_ui->updateStatus, m_ui->scheme.metricAlias.fontSizeSM, QFont::Normal,
+                    statusColor);
+    const int iconSize = m_ui->scheme.metricAlias.fontSize;
+    m_ui->updateIcon->setFixedSize(iconSize, iconSize);
+    m_ui->updateIcon->setPixmap(aboutIcon(statusIcon, m_ui->updateIcon->size(), this, statusColor));
     m_ui->updateStatus->setText(text);
     m_ui->updateStatus->setAccessibleName(text);
     m_ui->updateAction->setText(action);
     m_ui->updateAction->setAccessibleName(action);
+    m_ui->updateAction->setIconRef(actionIcon);
+    const bool primaryAction =
+        status.state == UpdateState::Available || status.state == UpdateState::Ready;
+    m_ui->updateAction->setButtonStyle(primaryAction ? AdButton::ButtonStyle::Solid
+                                                     : AdButton::ButtonStyle::Outline);
+    m_ui->updateAction->setAccentRole(primaryAction ? AdButton::AccentRole::Primary
+                                                    : AdButton::AccentRole::Neutral);
     m_ui->updateAction->setEnabled(
         status.state == UpdateState::Idle || status.state == UpdateState::Failed ||
         status.state == UpdateState::Available || status.state == UpdateState::Ready);
+    m_ui->updateAction->setVisible(m_ui->updateAction->isEnabled());
     m_ui->updateCancel->setText(tr("Cancel download"));
     m_ui->updateCancel->setVisible(status.state == UpdateState::Downloading);
     m_ui->updateProgress->setVisible(status.state == UpdateState::Downloading);
+    m_ui->updateProgress->setRange(0, status.total > 0 ? 1000 : 0);
     m_ui->updateProgress->setValue(
-        status.total > 0 ? static_cast<int>(status.received * 1000 / status.total) : 0);
+        status.total > 0
+            ? qRound(std::clamp(static_cast<double>(status.received) / status.total, 0.0, 1.0) *
+                     1000)
+            : 0);
     m_ui->updateProgress->setAccessibleName(tr("Update download progress"));
+    updateLayout();
 }
 
 void AboutPageWidget::changeEvent(QEvent* event) {

--- a/snow_shot/tests/about_page_tests.cpp
+++ b/snow_shot/tests/about_page_tests.cpp
@@ -27,6 +27,7 @@
 #include <QLabel>
 #include <QKeyEvent>
 #include <QPointer>
+#include <QProgressBar>
 #include <QScrollBar>
 #include <QTemporaryDir>
 #include <QTimer>
@@ -254,7 +255,10 @@ void largerTypeKeepsEveryActionReachable() {
     config.fontSize = 20;
     manager.setThemeStyleConfig(config);
     QCoreApplication::setApplicationVersion(QStringLiteral("12.34.56-beta.7+build.89"));
-    AboutPageWidget page(nullptr, [](const QUrl&) { return true; });
+    snow_shot::update::UpdateService updates({});
+    const_cast<snow_shot::update::UpdateStatus&>(updates.status()) = {
+        snow_shot::update::UpdateState::Ready, QStringLiteral("12.34.56-beta.8+build.90")};
+    AboutPageWidget page(nullptr, [](const QUrl&) { return true; }, &updates);
     page.resize(360, 360);
     page.show();
     flushEvents();
@@ -264,8 +268,8 @@ void largerTypeKeepsEveryActionReachable() {
     auto* artwork = child<QWidget>(page, "aboutArtwork");
     require(artwork->width() <= scroll->viewport()->width() && artwork->height() > 0,
             "artwork scales down to the available width with larger fonts");
-    for (const char* name : {"aboutCopyVersion", "aboutReleaseNotes", "aboutWebsite",
-                             "aboutSourceCode", "aboutFeedback"}) {
+    for (const char* name : {"aboutCopyVersion", "aboutReleaseNotes", "aboutUpdateAction",
+                             "aboutWebsite", "aboutSourceCode", "aboutFeedback"}) {
         auto* button = child<QAbstractButton>(page, name);
         scroll->ensureWidgetVisible(button);
         flushEvents();
@@ -301,6 +305,148 @@ void updatePolicyAndUnavailableCopy() {
     require(child<QLabel>(page, "aboutUpdateStatus")->text() ==
                 QStringLiteral("Automatic updates are unavailable for this copy."),
             "unavailable update status explains the disabled action");
+}
+
+void updateStatesFitTheVersionPanel() {
+    using namespace snow_shot::update;
+    using adqt::widgets::AdButton;
+    UpdateService updates({});
+    // Inject presentation snapshots without networking, downloads, or restart side effects.
+    auto& status = const_cast<UpdateStatus&>(updates.status());
+    QCoreApplication::setApplicationVersion(QStringLiteral(SNOW_SHOT_TEST_VERSION));
+    AboutPageWidget page(nullptr, [](const QUrl&) { return true; }, &updates);
+    auto* panel = child<QFrame>(page, "aboutVersionPanel");
+    auto* label = child<QLabel>(page, "aboutUpdateStatus");
+    auto* action = child<AdButton>(page, "aboutUpdateAction");
+    auto* cancel = child<AdButton>(page, "aboutUpdateCancel");
+    auto* progress = child<QProgressBar>(page, "aboutUpdateProgress");
+    auto* scroll = child<adqt::widgets::AdScrollArea>(page, "pageScrollArea");
+    require(panel->isAncestorOf(label) && panel->isAncestorOf(action) &&
+                panel->isAncestorOf(cancel) && panel->isAncestorOf(progress),
+            "update feedback and actions belong to the current version surface");
+    require(action->sizeClass() == AdButton::SizeClass::Small &&
+                cancel->sizeClass() == AdButton::SizeClass::Small &&
+                action->focusPolicy() == Qt::StrongFocus &&
+                cancel->focusPolicy() == Qt::StrongFocus,
+            "update actions match the compact, keyboard accessible version controls");
+    page.show();
+    for (const auto appearance : {styles::ThemeAppearance::Light, styles::ThemeAppearance::Dark}) {
+        styles::ThemeManager::instance().setThemeAppearance(appearance);
+        const auto colors = styles::ThemeManager::instance().themeColorScheme().map;
+        for (const QString& locale :
+             {QStringLiteral("en_US"), QStringLiteral("zh_CN"), QStringLiteral("zh_TW")}) {
+            QTranslator translator;
+            require(translator.load(QStringLiteral(SNOW_SHOT_TEST_TRANSLATIONS_DIR) +
+                                    QStringLiteral("/snow_shot_%1.qm").arg(locale)),
+                    "load update UI translations");
+            QCoreApplication::installTranslator(&translator);
+            for (const int width : {660, 360}) {
+                page.resize(width, 460);
+                for (const auto state :
+                     {UpdateState::Unavailable, UpdateState::Idle, UpdateState::Checking,
+                      UpdateState::Available, UpdateState::Downloading, UpdateState::Verifying,
+                      UpdateState::Ready, UpdateState::Applying, UpdateState::Failed}) {
+                    status = {state,
+                              QStringLiteral("12.34.56-beta.7+build.89"),
+                              {},
+                              5 * 1048576,
+                              20 * 1048576};
+                    if (state == UpdateState::Failed) {
+                        status.error = QStringLiteral("The download could not be completed. "
+                                                      "Check your connection and try again.");
+                    }
+                    updates.statusChanged();
+                    flushEvents();
+                    const bool actionable =
+                        state == UpdateState::Idle || state == UpdateState::Available ||
+                        state == UpdateState::Ready || state == UpdateState::Failed;
+                    require(action->isVisible() == actionable && action->isEnabled() == actionable,
+                            "only actionable update states display a primary control");
+                    require(cancel->isVisible() == (state == UpdateState::Downloading) &&
+                                progress->isVisible() == (state == UpdateState::Downloading),
+                            "download controls are confined to the downloading state");
+                    require(action->buttonStyle() ==
+                                ((state == UpdateState::Available || state == UpdateState::Ready)
+                                     ? AdButton::ButtonStyle::Solid
+                                     : AdButton::ButtonStyle::Outline),
+                            "download and restart receive the primary visual emphasis");
+                    require(!child<QLabel>(page, "aboutUpdateIcon")->pixmap().isNull(),
+                            "every update state has a rendered status icon");
+                    require(label->textFormat() == Qt::PlainText &&
+                                label->accessibleName() == label->text(),
+                            "status remains readable as plain text and through accessibility");
+                    if (state == UpdateState::Failed) {
+                        require(label->palette().color(QPalette::WindowText) ==
+                                    colors.colorErrorText,
+                                "update errors follow the active theme's error color");
+                    }
+                    require(scroll->horizontalScrollBar()->maximum() == 0,
+                            "all update states and languages fit without horizontal scrolling");
+                    if (label->height() < label->heightForWidth(label->width())) {
+                        std::cerr << "Clipped update " << static_cast<int>(state) << ' ' << width
+                                  << ' ' << locale.toStdString() << ": " << label->width() << 'x'
+                                  << label->height() << " required "
+                                  << label->heightForWidth(label->width()) << '\n';
+                        std::cerr << "Panel width/minimum/hfw/height " << panel->width() << ' '
+                                  << panel->minimumSizeHint().width() << ' '
+                                  << panel->heightForWidth(panel->width()) << ' ' << panel->height()
+                                  << '\n';
+                        scroll->ensureWidgetVisible(label);
+                        flushEvents();
+                        snapshot(page, QStringLiteral("about-update-clipped"));
+                    }
+                    require(label->height() >= label->heightForWidth(label->width()),
+                            "wrapped update status text is not clipped");
+                    for (auto* button : {action, cancel}) {
+                        if (!button->isVisible()) {
+                            continue;
+                        }
+                        scroll->ensureWidgetVisible(button);
+                        flushEvents();
+                        require(scroll->viewport()->rect().contains(QRect(
+                                    button->mapTo(scroll->viewport(), QPoint()), button->size())),
+                                "update actions can be scrolled fully into view");
+                        const QRect statusRect(label->mapTo(panel, QPoint()), label->size());
+                        const QRect buttonRect(button->mapTo(panel, QPoint()), button->size());
+                        require(panel->rect().contains(buttonRect) &&
+                                    !statusRect.intersects(buttonRect),
+                                "update actions remain inside the card without overlapping status");
+                    }
+                    if (state == UpdateState::Downloading) {
+                        require(progress->value() == 250 && progress->maximum() == 1000 &&
+                                    progress->height() <= 8,
+                                "download progress is accurate and uses a slim track");
+                    }
+                    if (locale == QStringLiteral("en_US")) {
+                        scroll->verticalScrollBar()->setValue(0);
+                        flushEvents();
+                        snapshot(page, QStringLiteral("about-update-%1-%2-%3")
+                                           .arg(appearance == styles::ThemeAppearance::Light
+                                                    ? QStringLiteral("light")
+                                                    : QStringLiteral("dark"))
+                                           .arg(width)
+                                           .arg(static_cast<int>(state)));
+                    }
+                }
+            }
+            QCoreApplication::removeTranslator(&translator);
+        }
+    }
+    status = {UpdateState::Downloading, {}, {}, 0, 0};
+    updates.statusChanged();
+    require(progress->minimum() == 0 && progress->maximum() == 0,
+            "downloads of unknown size use indeterminate progress");
+    require(label->text() == QStringLiteral("Downloading update…"),
+            "unknown download sizes do not display a misleading zero total");
+    status = {UpdateState::Ready, QStringLiteral("1.2.3"),
+              QStringLiteral("Close the recording first.")};
+    updates.statusChanged();
+    require(action->isEnabled() && label->text().contains(status.error) &&
+                label->palette().color(QPalette::WindowText) ==
+                    styles::ThemeManager::instance().themeColorScheme().map.colorWarningText,
+            "blocked restarts keep their action and show the reason in the warning color");
+    page.hide();
+    styles::ThemeManager::instance().setThemeAppearance(styles::ThemeAppearance::Light);
 }
 
 void traySettingsAndFunctionNavigation() {
@@ -350,6 +496,9 @@ void traySettingsAndFunctionNavigation() {
 }
 
 void mainNavigationSearchThemesAndLanguages() {
+    snow_shot::update::UpdateService updates({}, qApp);
+    const_cast<snow_shot::update::UpdateStatus&>(updates.status()).state =
+        snow_shot::update::UpdateState::Idle;
     QCoreApplication::setApplicationVersion(QStringLiteral(SNOW_SHOT_TEST_VERSION));
     const auto& registry = settings::builtInSettingsRegistry();
     require(registry.isValid(), "About preserves catalog validity");
@@ -564,6 +713,7 @@ int main(int argc, char** argv) {
     projectLinkSurfacesMatchStandardButtons();
     projectLinksAreExplicitAccessibleAndRecoverable();
     updatePolicyAndUnavailableCopy();
+    updateStatesFitTheVersionPanel();
     traySettingsAndFunctionNavigation();
     mainNavigationSearchThemesAndLanguages();
     largerTypeKeepsEveryActionReachable();


### PR DESCRIPTION
Give each update state a themed status icon and semantic color, keep download/restart actions compact and visible only when actionable, use an indeterminate progress bar for unknown download sizes, and stack the version/update actions by measured width so every state fits the card across themes, languages, and narrow layouts.