### PR TITLE
feat(shortcuts): run dismiss actions on key or button release instead of press

### DIFF
--- a/snow_shot/CMakeLists.txt
+++ b/snow_shot/CMakeLists.txt
@@ -621,6 +621,8 @@ target_compile_definitions(snow_shot_translation PRIVATE
 )
 
 add_library(snow_shot_window_shortcuts STATIC
+    include/snow_shot/presentation/mousereleaseactioncontroller.h
+    src/presentation/services/mousereleaseactioncontroller.cpp
     include/snow_shot/presentation/windowshortcutmanager.h
     src/presentation/services/windowshortcutmanager.cpp
 )
@@ -1935,6 +1937,12 @@ if(SNOW_SHOT_BUILD_TESTS)
     add_executable(snow-shot-window-shortcut-manager-tests
         tests/window_shortcut_manager_tests.cpp
     )
+    add_executable(snow-shot-mouse-release-action-tests tests/mouse_release_action_tests.cpp)
+    target_link_libraries(snow-shot-mouse-release-action-tests PRIVATE snow_shot_window_shortcuts)
+    snow_shot_import_offscreen_platform(snow-shot-mouse-release-action-tests)
+    add_test(NAME snow-shot-mouse-release-action-tests
+        COMMAND snow-shot-mouse-release-action-tests -platform offscreen)
+    set_tests_properties(snow-shot-mouse-release-action-tests PROPERTIES LABELS "unit")
     target_link_libraries(snow-shot-window-shortcut-manager-tests PRIVATE
         snow_shot_window_shortcuts
         Qt6::Widgets
@@ -2513,6 +2521,8 @@ if(SNOW_SHOT_BUILD_TESTS)
     )
     add_test(NAME snow-shot-direct-capture-history-rendering-tests
         COMMAND snow-shot-screenshot-canvas-renderer-tests --direct-capture-history-rendering)
+    add_test(NAME snow-shot-overlay-close-release-tests
+        COMMAND snow-shot-screenshot-canvas-renderer-tests --close-release-only -platform offscreen)
     set_tests_properties(snow-shot-direct-capture-history-rendering-tests PROPERTIES
         ENVIRONMENT "${_SNOW_SHOT_OFFSCREEN_QPA_ENVIRONMENT}"
         ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Qt6::Core>"
@@ -3441,6 +3451,21 @@ if(SNOW_SHOT_BUILD_TESTS)
     endif()
     add_test(NAME snow-shot-screen-recording-shortcut-tests
         COMMAND snow-shot-screen-recording-shortcut-tests)
+    if(WIN32)
+        foreach(_close_release_pair IN ITEMS
+                "overlay|snow-shot-screenshot-canvas-renderer-tests"
+                "pinned|snow-shot-pinned-window-tests"
+                "recording|snow-shot-screen-recording-shortcut-tests")
+            string(REPLACE "|" ";" _close_release_parts "${_close_release_pair}")
+            list(GET _close_release_parts 0 _close_release_name)
+            list(GET _close_release_parts 1 _close_release_target)
+            add_test(NAME snow-shot-${_close_release_name}-close-release-native-tests
+                COMMAND ${_close_release_target} --close-release-native -platform windows)
+            set_tests_properties(snow-shot-${_close_release_name}-close-release-native-tests
+                PROPERTIES LABELS "interactive;e2e;windows" RUN_SERIAL TRUE TIMEOUT 60
+                ENVIRONMENT "QT_QPA_PLATFORM=windows")
+        endforeach()
+    endif()
     set_tests_properties(snow-shot-screen-recording-shortcut-tests PROPERTIES
         ENVIRONMENT "${_SNOW_SHOT_OFFSCREEN_QPA_ENVIRONMENT}"
         ENVIRONMENT_MODIFICATION "PATH=path_list_prepend:$<TARGET_FILE_DIR:Qt6::Core>"

--- a/snow_shot/include/snow_shot/presentation/mousereleaseactioncontroller.h
+++ b/snow_shot/include/snow_shot/presentation/mousereleaseactioncontroller.h
@@ -1,0 +1,46 @@
+#ifndef SNOW_SHOT_PRESENTATION_MOUSERELEASEACTIONCONTROLLER_H
+#define SNOW_SHOT_PRESENTATION_MOUSERELEASEACTIONCONTROLLER_H
+
+#include <QObject>
+#include <QPointer>
+#include <QWidget>
+
+#include <functional>
+
+namespace snow_shot::presentation {
+
+// Owns a dismissing mouse gesture until its release has finished dispatching.
+// The scope stays visible; interruptions discard the action rather than closing.
+class MouseReleaseActionController final : public QObject {
+  public:
+    explicit MouseReleaseActionController(QObject* parent = nullptr);
+    ~MouseReleaseActionController() override;
+
+    [[nodiscard]] bool arm(QWidget* scopeWindow, Qt::MouseButton button,
+                           std::function<void()> action);
+    void cancel();
+    [[nodiscard]] bool pending() const;
+    // Forward from the scope's nativeEvent, including directly sent non-client
+    // messages that do not pass through an application native event filter.
+    bool handleNativeEvent(void* message, qintptr* result);
+
+  protected:
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+  private:
+    void finish();
+    void releaseCapture();
+
+    QPointer<QWidget> m_scope;
+    QPointer<QWidget> m_capture;
+    QMetaObject::Connection m_scopeDestroyed;
+    std::function<void()> m_action;
+    Qt::MouseButton m_button = Qt::NoButton;
+    quint64 m_revision = 0;
+    bool m_ownsCapture = false;
+    bool m_finishing = false;
+};
+
+} // namespace snow_shot::presentation
+
+#endif

--- a/snow_shot/include/snow_shot/presentation/screenshotoverlayeventsink.h
+++ b/snow_shot/include/snow_shot/presentation/screenshotoverlayeventsink.h
@@ -7,6 +7,8 @@
 
 class ScreenshotOverlayWindow;
 
+enum class ScreenshotOverlayRightClickResult { Ignored, Handled, CancelCapture };
+
 class ScreenshotOverlayEventSink {
   public:
     virtual ~ScreenshotOverlayEventSink() = default;
@@ -20,8 +22,9 @@ class ScreenshotOverlayEventSink {
                                         const QPointF& localPosition) = 0;
     virtual void handleOverlayMouseRelease(ScreenshotOverlayWindow* overlay,
                                            const QPointF& localPosition) = 0;
-    [[nodiscard]] virtual bool handleOverlayRightClick(ScreenshotOverlayWindow* overlay,
-                                                       const QPointF& localPosition) = 0;
+    [[nodiscard]] virtual ScreenshotOverlayRightClickResult
+    handleOverlayRightClick(ScreenshotOverlayWindow* overlay, const QPointF& localPosition) = 0;
+    virtual void completeRightClickCancellation() {}
     // Optional completion-gesture notifications. Lightweight event sinks can
     // keep the defaults when they only handle the mouse and keyboard surface.
     virtual void handleUnhandledLeftDoubleClick() {}

--- a/snow_shot/include/snow_shot/presentation/screenshotoverlayinputhandler.h
+++ b/snow_shot/include/snow_shot/presentation/screenshotoverlayinputhandler.h
@@ -2,6 +2,7 @@
 #define SNOW_SHOT_PRESENTATION_SCREENSHOTOVERLAYINPUTHANDLER_H
 
 #include "snow_shot/platform/physicalcursor.h"
+#include "snow_shot/presentation/screenshotoverlayeventsink.h"
 #include "snow_shot/presentation/screenshotselectiongeometry.h"
 
 #include <QPoint>
@@ -141,8 +142,9 @@ class ScreenshotOverlayInputHandler final {
                                               bool leftButtonActive) const;
     void handleMouseMove(ScreenshotOverlayWindow* overlay, const QPointF& localPosition);
     void handleMouseRelease(ScreenshotOverlayWindow* overlay, const QPointF& localPosition);
-    [[nodiscard]] bool handleRightClick(ScreenshotOverlayWindow* overlay,
-                                        const QPointF& localPosition);
+    void completeRightClickCancellation();
+    [[nodiscard]] ScreenshotOverlayRightClickResult
+    handleRightClick(ScreenshotOverlayWindow* overlay, const QPointF& localPosition);
     void handleUnhandledLeftDoubleClick();
     void handleUnhandledMiddleClick();
     [[nodiscard]] bool handleWheel(ScreenshotOverlayWindow* overlay, const QPointF& localPosition,

--- a/snow_shot/include/snow_shot/presentation/screenshotoverlayinteractionadapter.h
+++ b/snow_shot/include/snow_shot/presentation/screenshotoverlayinteractionadapter.h
@@ -27,8 +27,10 @@ class ScreenshotOverlayEventAdapter final : public ScreenshotOverlayEventSink {
                                 const QPointF& localPosition) override;
     void handleOverlayMouseRelease(ScreenshotOverlayWindow* overlay,
                                    const QPointF& localPosition) override;
-    [[nodiscard]] bool handleOverlayRightClick(ScreenshotOverlayWindow* overlay,
-                                               const QPointF& localPosition) override;
+    void completeRightClickCancellation() override;
+    [[nodiscard]] ScreenshotOverlayRightClickResult
+    handleOverlayRightClick(ScreenshotOverlayWindow* overlay,
+                            const QPointF& localPosition) override;
     void handleUnhandledLeftDoubleClick() override;
     void handleUnhandledMiddleClick() override;
     [[nodiscard]] bool handleOverlayWheel(ScreenshotOverlayWindow* overlay,

--- a/snow_shot/include/snow_shot/presentation/screenshotoverlaywindow.h
+++ b/snow_shot/include/snow_shot/presentation/screenshotoverlaywindow.h
@@ -3,6 +3,8 @@
 
 #include "snow_shot/presentation/screenshotscrollingtypes.h"
 
+#include "snow_shot/presentation/mousereleaseactioncontroller.h"
+
 #include <QColor>
 #include <QJsonObject>
 #include <QRegion>
@@ -100,6 +102,7 @@ class ScreenshotOverlayWindow final : public QWidget {
     void updateWindowMask();
 
     ScreenshotOverlayEventSink& m_eventSink;
+    snow_shot::presentation::MouseReleaseActionController m_mouseReleaseAction;
     SnowCanvasWidget* m_canvas = nullptr;
     ScreenshotScrollingThumbnailWidget* m_scrollingThumbnail = nullptr;
     std::unique_ptr<ScreenshotOverlayFramePresenter> m_framePresenter;

--- a/snow_shot/include/snow_shot/presentation/screenshotpinnedwindow.h
+++ b/snow_shot/include/snow_shot/presentation/screenshotpinnedwindow.h
@@ -11,6 +11,8 @@
 #include "snow_shot/storage/pinnedwindowtypes.h"
 
 #include <QByteArray>
+#include "snow_shot/presentation/mousereleaseactioncontroller.h"
+
 #include <QColor>
 #include <QImage>
 #include <QMap>
@@ -293,6 +295,7 @@ class ScreenshotPinnedWindow final : public QWidget {
 
     SnowCanvasRuntime m_runtime;
     std::unique_ptr<snow_shot::presentation::WindowShortcutManager> m_shortcutManager;
+    snow_shot::presentation::MouseReleaseActionController m_mouseReleaseAction;
     std::unique_ptr<screenshot_pinned_window_native::SystemMoveKeyboard> m_systemMoveKeyboard;
     std::unique_ptr<snow_shot::platform::PhysicalCursor> m_physicalCursor;
     QMap<QString, quint64> m_pinnedShortcutBindings;

--- a/snow_shot/include/snow_shot/presentation/windowshortcutmanager.h
+++ b/snow_shot/include/snow_shot/presentation/windowshortcutmanager.h
@@ -37,15 +37,21 @@ class WindowShortcutManager final : public QObject {
     };
 
     struct Binding {
+        enum class ActivationTrigger { Press, Release };
+
         QString id;
         QList<QKeyCombination> keyCombinations;
         int priority = 0;
         bool autoRepeat = false;
+        // Release actions reserve the initial press and execute only after its
+        // physical release. They cannot also define held-control callbacks.
+        ActivationTrigger activationTrigger = ActivationTrigger::Press;
         // Held contextual shortcuts may tolerate a narrowly scoped extra
         // modifier (for example Shift followed by Space during a resize).
         Qt::KeyboardModifiers allowedAdditionalModifiers = Qt::NoModifier;
-        std::function<bool(const ActivationContext&)> canActivate =
-            [](const ActivationContext&) { return true; };
+        std::function<bool(const ActivationContext&)> canActivate = [](const ActivationContext&) {
+            return true;
+        };
         std::function<bool(const ActivationContext&)> activate;
         // Optional key-release action. It is used by held local modifiers
         // whose state must end before the mouse gesture is released.

--- a/snow_shot/src/presentation/ocr/screenshotrecognitionwindow.cpp
+++ b/snow_shot/src/presentation/ocr/screenshotrecognitionwindow.cpp
@@ -555,16 +555,29 @@ void ScreenshotRecognitionWindow::registerWindowShortcuts() {
     cancel.id = QStringLiteral("recognition.cancel");
     cancel.keyCombinations = {QKeyCombination(Qt::NoModifier, Qt::Key_Escape)};
     cancel.priority = ShortcutManager::StandardPriority::WindowCommand;
+    cancel.activationTrigger = ShortcutManager::Binding::ActivationTrigger::Release;
     cancel.canActivate = [this](const ShortcutManager::ActivationContext& context) {
-        return context.scopeWindow == this && isVisible();
+        return context.scopeWindow == this && isVisible() &&
+               (m_tableEditor == nullptr || !m_tableEditor->isEditingCell());
     };
     cancel.activate = [this](const auto&) {
-        if (m_tableEditor == nullptr || !m_tableEditor->cancelActiveEdit()) {
-            m_actions.handleCancel();
-        }
+        m_actions.handleCancel();
         return true;
     };
     static_cast<void>(m_shortcutManager->addBinding(this, std::move(cancel)));
+
+    ShortcutManager::Binding cancelEdit;
+    cancelEdit.id = QStringLiteral("recognition.cancel_edit");
+    cancelEdit.keyCombinations = {QKeyCombination(Qt::NoModifier, Qt::Key_Escape)};
+    cancelEdit.priority = ShortcutManager::StandardPriority::WindowCommand + 1;
+    cancelEdit.canActivate = [this](const auto& context) {
+        return context.scopeWindow == this && isVisible() && m_tableEditor &&
+               m_tableEditor->isEditingCell();
+    };
+    cancelEdit.activate = [this](const auto&) { return m_tableEditor->cancelActiveEdit(); };
+    cancelEdit.release = [](const auto&) { return true; };
+    cancelEdit.cancel = [] {};
+    static_cast<void>(m_shortcutManager->addBinding(this, std::move(cancelEdit)));
 
     const auto recognitionCommandsAllowed =
         [this](const ShortcutManager::ActivationContext& context) {

--- a/snow_shot/src/presentation/overlay/screenshotoverlayinputhandler.cpp
+++ b/snow_shot/src/presentation/overlay/screenshotoverlayinputhandler.cpp
@@ -425,39 +425,43 @@ void ScreenshotOverlayInputHandler::finishSelectionDrag(ScreenshotOverlayWindow*
     m_context.actions.updateColorPickerForOverlay(overlay, localPosition);
 }
 
-bool ScreenshotOverlayInputHandler::handleRightClick(ScreenshotOverlayWindow* overlay,
-                                                     const QPointF& localPosition) {
+ScreenshotOverlayRightClickResult
+ScreenshotOverlayInputHandler::handleRightClick(ScreenshotOverlayWindow* overlay,
+                                                const QPointF& localPosition) {
     if (m_externalDragActive)
-        return true;
+        return ScreenshotOverlayRightClickResult::Handled;
     if (m_canvasColorSamplingArmed) {
         cancelCanvasColorSampling();
-        return true;
+        return ScreenshotOverlayRightClickResult::Handled;
     }
     if (recognitionTool(m_context.interaction.activeTool())) {
-        return true;
+        return ScreenshotOverlayRightClickResult::Handled;
     }
     if (!m_context.interaction.moveToolActive()) {
-        return false;
+        return ScreenshotOverlayRightClickResult::Ignored;
     }
 
     const QPointF virtualPosition = virtualPositionForOverlay(overlay, localPosition);
     const QPoint physicalPoint = physicalPositionForCanvasPoint(virtualPosition);
     if (m_context.interaction.intelligentSelecting()) {
-        resetTransientShortcuts();
-        m_context.actions.cancelCapture();
-        return true;
+        return ScreenshotOverlayRightClickResult::CancelCapture;
     }
 
     if (m_context.interaction.manualSelecting() || m_context.interaction.movingSelection()) {
         resetTransientShortcuts();
         if (m_context.actions.returnToCurrentScreenshot()) {
-            return true;
+            return ScreenshotOverlayRightClickResult::Handled;
         }
         m_context.actions.returnToIntelligentSelection(physicalPoint);
-        return true;
+        return ScreenshotOverlayRightClickResult::Handled;
     }
 
-    return false;
+    return ScreenshotOverlayRightClickResult::Ignored;
+}
+
+void ScreenshotOverlayInputHandler::completeRightClickCancellation() {
+    resetTransientShortcuts();
+    m_context.actions.cancelCapture();
 }
 
 bool ScreenshotOverlayInputHandler::handleWheel(ScreenshotOverlayWindow* overlay,

--- a/snow_shot/src/presentation/overlay/screenshotoverlayinteractionadapter.cpp
+++ b/snow_shot/src/presentation/overlay/screenshotoverlayinteractionadapter.cpp
@@ -46,12 +46,19 @@ void ScreenshotOverlayEventAdapter::handleOverlayMouseRelease(ScreenshotOverlayW
     }
 }
 
-bool ScreenshotOverlayEventAdapter::handleOverlayRightClick(ScreenshotOverlayWindow* overlay,
-                                                            const QPointF& localPosition) {
+ScreenshotOverlayRightClickResult
+ScreenshotOverlayEventAdapter::handleOverlayRightClick(ScreenshotOverlayWindow* overlay,
+                                                       const QPointF& localPosition) {
     if (m_inputHandler == nullptr) {
-        return false;
+        return ScreenshotOverlayRightClickResult::Ignored;
     }
     return m_inputHandler->handleRightClick(overlay, localPosition);
+}
+
+void ScreenshotOverlayEventAdapter::completeRightClickCancellation() {
+    if (m_inputHandler) {
+        m_inputHandler->completeRightClickCancellation();
+    }
 }
 
 void ScreenshotOverlayEventAdapter::handleUnhandledLeftDoubleClick() {

--- a/snow_shot/src/presentation/overlay/screenshotoverlayshortcutcontroller.cpp
+++ b/snow_shot/src/presentation/overlay/screenshotoverlayshortcutcontroller.cpp
@@ -170,6 +170,9 @@ struct ScreenshotOverlayShortcutController::Impl {
         for (const QString& actionId : screenshotIds) {
             ShortcutManager::Binding binding;
             binding.id = QStringLiteral("screenshot.configured.") + actionId;
+            if (actionId == QStringLiteral("cancel_screenshot")) {
+                binding.activationTrigger = ShortcutManager::Binding::ActivationTrigger::Release;
+            }
             binding.priority = ShortcutManager::StandardPriority::ScreenshotShortcut;
             binding.autoRepeat = actionId.startsWith(QStringLiteral("move_cursor_"));
             binding.canActivate = [this, actionId](const auto&) {

--- a/snow_shot/src/presentation/overlay/screenshotoverlaywindow.cpp
+++ b/snow_shot/src/presentation/overlay/screenshotoverlaywindow.cpp
@@ -513,6 +513,9 @@ void ScreenshotOverlayWindow::keyPressEvent(QKeyEvent* event) {
 
 bool ScreenshotOverlayWindow::nativeEvent(const QByteArray& eventType, void* message,
                                           qintptr* result) {
+    if (m_mouseReleaseAction.handleNativeEvent(message, result)) {
+        return true;
+    }
 #if defined(Q_OS_WIN) || defined(_WIN32)
     Q_UNUSED(eventType);
     if (message == nullptr || result == nullptr) {
@@ -694,10 +697,16 @@ bool ScreenshotOverlayWindow::handleCanvasMouseEvent(QMouseEvent* event) {
         return false;
     }
 
-    if (event->type() == QEvent::MouseButtonPress && event->button() == Qt::RightButton &&
-        m_eventSink.handleOverlayRightClick(this, event->position())) {
-        event->accept();
-        return true;
+    if (event->type() == QEvent::MouseButtonPress && event->button() == Qt::RightButton) {
+        const auto action = m_eventSink.handleOverlayRightClick(this, event->position());
+        if (action == ScreenshotOverlayRightClickResult::CancelCapture) {
+            static_cast<void>(m_mouseReleaseAction.arm(
+                this, Qt::RightButton, [this] { m_eventSink.completeRightClickCancellation(); }));
+        }
+        if (action != ScreenshotOverlayRightClickResult::Ignored) {
+            event->accept();
+            return true;
+        }
     }
 
     if (event->type() == QEvent::MouseMove && !event->buttons().testFlag(Qt::LeftButton)) {

--- a/snow_shot/src/presentation/pinned/screenshotpinnedwindow.cpp
+++ b/snow_shot/src/presentation/pinned/screenshotpinnedwindow.cpp
@@ -789,6 +789,7 @@ void ScreenshotPinnedWindow::registerWindowShortcuts() {
 
     ShortcutManager::Binding closeWindow;
     closeWindow.id = QStringLiteral("pinned.close");
+    closeWindow.activationTrigger = ShortcutManager::Binding::ActivationTrigger::Release;
     closeWindow.priority = ShortcutManager::StandardPriority::WindowCommand + 1;
     closeWindow.canActivate = localCommandsAllowed;
     closeWindow.activate = [this](const auto&) {
@@ -1168,6 +1169,9 @@ bool ScreenshotPinnedWindow::event(QEvent* event) {
 
 bool ScreenshotPinnedWindow::nativeEvent(const QByteArray& eventType, void* message,
                                          qintptr* result) {
+    if (m_mouseReleaseAction.handleNativeEvent(message, result)) {
+        return true;
+    }
     if (m_closing) {
         return QWidget::nativeEvent(eventType, message, result);
     }
@@ -5147,7 +5151,8 @@ bool ScreenshotPinnedWindow::handleDoubleClick(const QPoint& position) {
     if (action == QStringLiteral("thumbnail_mode")) {
         setThumbnailMode(!m_thumbnailMode);
     } else if (action == QStringLiteral("close")) {
-        requestUserClose();
+        static_cast<void>(
+            m_mouseReleaseAction.arm(this, Qt::LeftButton, [this] { requestUserClose(); }));
     }
     return true;
 }
@@ -5167,7 +5172,8 @@ bool ScreenshotPinnedWindow::handleMiddleClick(const QPoint& position) {
     } else if (action == QStringLiteral("thumbnail_mode")) {
         setThumbnailMode(!m_thumbnailMode);
     } else if (action == QStringLiteral("close")) {
-        requestUserClose();
+        static_cast<void>(
+            m_mouseReleaseAction.arm(this, Qt::MiddleButton, [this] { requestUserClose(); }));
     }
     return true;
 }

--- a/snow_shot/src/presentation/recording/screenrecordingshortcutcontroller.cpp
+++ b/snow_shot/src/presentation/recording/screenrecordingshortcutcontroller.cpp
@@ -43,6 +43,9 @@ ScreenRecordingShortcutController::ScreenRecordingShortcutController(
     for (auto action = recordingShortcuts.cbegin(); action != recordingShortcuts.cend(); ++action) {
         ShortcutManager::Binding binding;
         binding.id = QStringLiteral("recording.control.") + action.key();
+        if (action.key() == QStringLiteral("end_recording")) {
+            binding.activationTrigger = ShortcutManager::Binding::ActivationTrigger::Release;
+        }
         binding.priority = ShortcutManager::StandardPriority::WindowCommand;
         binding.canActivate = [this, actionId = action.key()](const auto& context) {
             return canActivate(context) &&

--- a/snow_shot/src/presentation/services/mousereleaseactioncontroller.cpp
+++ b/snow_shot/src/presentation/services/mousereleaseactioncontroller.cpp
@@ -1,0 +1,186 @@
+#include "snow_shot/presentation/mousereleaseactioncontroller.h"
+
+#include <QApplication>
+#include <QContextMenuEvent>
+#include <QMouseEvent>
+#include <QWindow>
+
+#include <utility>
+
+#ifdef Q_OS_WIN
+#include <qt_windows.h>
+#endif
+
+namespace snow_shot::presentation {
+
+MouseReleaseActionController::MouseReleaseActionController(QObject* parent) : QObject(parent) {
+    qApp->installEventFilter(this);
+}
+
+MouseReleaseActionController::~MouseReleaseActionController() {
+    cancel();
+    qApp->removeEventFilter(this);
+}
+
+bool MouseReleaseActionController::arm(QWidget* scopeWindow, Qt::MouseButton button,
+                                       std::function<void()> action) {
+    if (pending()) {
+        return false;
+    }
+    if (!scopeWindow || !scopeWindow->isVisible() || button == Qt::NoButton || !action) {
+        return false;
+    }
+    QWidget* scope = scopeWindow->window();
+    QWidget* grabber = QWidget::mouseGrabber();
+    if (grabber && grabber->window() != scope) {
+        return false;
+    }
+#ifdef Q_OS_WIN
+    if (QGuiApplication::platformName() == QStringLiteral("windows")) {
+        const HWND capture = GetCapture();
+        const HWND root = reinterpret_cast<HWND>(scope->winId());
+        if (capture && capture != root && !IsChild(root, capture)) {
+            return false;
+        }
+    }
+#endif
+    m_scope = scope;
+    m_capture = grabber ? grabber : scope;
+    m_ownsCapture = grabber == nullptr;
+    if (m_ownsCapture) {
+        m_capture->grabMouse();
+    }
+    bool captured = QWidget::mouseGrabber() == m_capture;
+#ifdef Q_OS_WIN
+    if (QGuiApplication::platformName() == QStringLiteral("windows")) {
+        captured = captured && GetCapture() == reinterpret_cast<HWND>(m_capture->winId());
+    }
+#endif
+    if (!captured) {
+        cancel();
+        return false;
+    }
+    ++m_revision;
+    m_button = button;
+    m_action = std::move(action);
+    m_scopeDestroyed = connect(scope, &QObject::destroyed, this, [this] { cancel(); });
+    return true;
+}
+
+bool MouseReleaseActionController::pending() const {
+    return m_button != Qt::NoButton || m_finishing;
+}
+
+void MouseReleaseActionController::releaseCapture() {
+    const auto capture = std::exchange(m_capture, {});
+    if (std::exchange(m_ownsCapture, false) && capture && QWidget::mouseGrabber() == capture) {
+        capture->releaseMouse();
+    }
+}
+
+void MouseReleaseActionController::cancel() {
+    disconnect(m_scopeDestroyed);
+    m_scopeDestroyed = {};
+    ++m_revision;
+    m_button = Qt::NoButton;
+    m_finishing = false;
+    m_action = {};
+    m_scope.clear();
+    releaseCapture();
+}
+
+void MouseReleaseActionController::finish() {
+    if (m_button == Qt::NoButton) {
+        return;
+    }
+    m_button = Qt::NoButton;
+    m_finishing = true;
+    auto action = std::exchange(m_action, {});
+    const auto revision = m_revision;
+    // Clear capture ownership before ReleaseCapture emits synchronous messages.
+    releaseCapture();
+    QMetaObject::invokeMethod(
+        this,
+        [this, revision, action = std::move(action)] {
+            if (revision != m_revision || !m_finishing || !m_scope || !m_scope->isVisible()) {
+                return;
+            }
+            cancel();
+            action(); // May destroy both the scope and this controller.
+        },
+        Qt::QueuedConnection);
+}
+
+bool MouseReleaseActionController::eventFilter(QObject* watched, QEvent* event) {
+    // Let QWidgetWindow finish routing and release its implicit mouse capture
+    // before consuming the QWidget delivery of the terminating event.
+    if (!pending() || qobject_cast<QWindow*>(watched)) {
+        return false;
+    }
+    if (event->type() == QEvent::ApplicationDeactivate ||
+        (watched == m_scope && (event->type() == QEvent::Hide || event->type() == QEvent::Destroy ||
+                                event->type() == QEvent::WindowDeactivate)) ||
+        (watched == m_capture && event->type() == QEvent::UngrabMouse)) {
+        cancel();
+        return false;
+    }
+    if (event->type() == QEvent::ContextMenu) {
+        auto* context = static_cast<QContextMenuEvent*>(event);
+        auto* widget = qobject_cast<QWidget*>(watched);
+        if (context->reason() == QContextMenuEvent::Mouse && widget &&
+            widget->window() == m_scope) {
+            event->accept();
+            return true;
+        }
+    }
+    if (event->type() == QEvent::MouseButtonRelease || event->type() == QEvent::MouseButtonPress ||
+        event->type() == QEvent::MouseButtonDblClick) {
+        auto* mouse = static_cast<QMouseEvent*>(event);
+        if (mouse->button() == m_button) {
+            event->accept();
+            if (event->type() == QEvent::MouseButtonRelease) {
+                finish();
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
+bool MouseReleaseActionController::handleNativeEvent(void* message, qintptr* result) {
+#ifdef Q_OS_WIN
+    if (!pending() || !m_scope) {
+        return false;
+    }
+    auto* native = static_cast<MSG*>(message);
+    if (!native) {
+        return false;
+    }
+    if (native->message == WM_CAPTURECHANGED && m_capture &&
+        native->hwnd == reinterpret_cast<HWND>(m_capture->winId()) &&
+        reinterpret_cast<HWND>(native->lParam) != reinterpret_cast<HWND>(m_capture->winId())) {
+        cancel();
+        return false;
+    }
+    if (native->hwnd != reinterpret_cast<HWND>(m_scope->winId())) {
+        return false;
+    }
+    const Qt::MouseButton released = native->message == WM_NCLBUTTONUP   ? Qt::LeftButton
+                                     : native->message == WM_NCRBUTTONUP ? Qt::RightButton
+                                     : native->message == WM_NCMBUTTONUP ? Qt::MiddleButton
+                                                                         : Qt::NoButton;
+    if (released != Qt::NoButton && released == m_button) {
+        finish();
+        if (result) {
+            *result = 0;
+        }
+        return true;
+    }
+#else
+    Q_UNUSED(message)
+    Q_UNUSED(result)
+#endif
+    return false;
+}
+
+} // namespace snow_shot::presentation

--- a/snow_shot/src/presentation/services/windowshortcutmanager.cpp
+++ b/snow_shot/src/presentation/services/windowshortcutmanager.cpp
@@ -28,6 +28,7 @@ struct UnreleasedKeyState final : QObject {
     explicit UnreleasedKeyState(QObject* parent) : QObject(parent) {}
     QSet<int> keys;
     QHash<int, quint64> revisions;
+    QHash<int, QPointer<WindowShortcutManager>> releaseOwners;
 };
 
 UnreleasedKeyState& applicationKeyState() {
@@ -97,6 +98,11 @@ QList<QKeyCombination> normalizedCombinations(const QList<QKeyCombination>& comb
 } // namespace
 
 struct WindowShortcutManager::Impl {
+    struct PendingActivation {
+        BindingHandle handle = 0;
+        QPointer<QWidget> scope;
+    };
+
     struct RegisteredBinding {
         BindingHandle handle = 0;
         quint64 order = 0;
@@ -182,7 +188,17 @@ struct WindowShortcutManager::Impl {
             }
         }
         invalidateHeldKeys();
-        cancelHeldBindings();
+        cancelHeldBindings(false);
+        // WindowDeactivate precedes activation of the next toolbar/tool window.
+        // Resolve the destination after Qt has completed that focus transition.
+        QMetaObject::invokeMethod(
+            &q,
+            [this] {
+                if (scopeForReceiver(QApplication::activeWindow()) == nullptr) {
+                    cancelReleaseActivations();
+                }
+            },
+            Qt::QueuedConnection);
     }
 
     [[nodiscard]] QWidget* scopeForReceiver(QObject* receiver) {
@@ -244,7 +260,9 @@ struct WindowShortcutManager::Impl {
         return nullptr;
     }
 
-    [[nodiscard]] bool inputSuspended() const { return !m_inputSuspensions.isEmpty(); }
+    [[nodiscard]] bool inputSuspended() const {
+        return !m_inputSuspensions.isEmpty();
+    }
 
     void invalidateHeldKeys() {
         for (const int key : m_heldKeys) {
@@ -254,7 +272,10 @@ struct WindowShortcutManager::Impl {
         m_heldKeys.clear();
     }
 
-    void cancelHeldBindings() {
+    void cancelHeldBindings(bool cancelRelease = true) {
+        if (cancelRelease) {
+            cancelReleaseActivations();
+        }
         struct PendingCancellation {
             QPointer<QObject> owner;
             std::function<void()> cancel;
@@ -262,6 +283,9 @@ struct WindowShortcutManager::Impl {
         QVector<PendingCancellation> pending;
         for (RegisteredBinding& registered : m_bindings) {
             if (!registered.activeReleaseCombinations.isEmpty()) {
+                for (const auto combination : registered.activeReleaseCombinations) {
+                    applicationKeyState().releaseOwners.remove(combination.key());
+                }
                 pending.push_back({registered.owner, registered.binding.cancel});
                 registered.activeReleaseCombinations.clear();
             }
@@ -275,10 +299,21 @@ struct WindowShortcutManager::Impl {
         }
     }
 
+    void cancelReleaseActivations(BindingHandle handle = 0, QWidget* scope = nullptr) {
+        for (auto& pending : m_releaseActivations) {
+            if ((handle == 0 || pending.handle == handle) &&
+                (scope == nullptr || pending.scope == scope)) {
+                // Still drain this sequence if its release reaches us. A fresh
+                // physical press after interruption may replace the reservation.
+                pending.handle = 0;
+            }
+        }
+    }
+
     [[nodiscard]] RegisteredBinding* findBinding(BindingHandle handle) {
-        const auto binding = std::find_if(
-            m_bindings.begin(), m_bindings.end(),
-            [handle](const RegisteredBinding& item) { return item.handle == handle; });
+        const auto binding =
+            std::find_if(m_bindings.begin(), m_bindings.end(),
+                         [handle](const RegisteredBinding& item) { return item.handle == handle; });
         return binding != m_bindings.end() ? &*binding : nullptr;
     }
 
@@ -287,17 +322,16 @@ struct WindowShortcutManager::Impl {
         const bool staleAutoRepeat = isStaleAutoRepeat(event);
         for (RegisteredBinding& registered : m_bindings) {
             if (registered.owner == nullptr ||
-                (event.isAutoRepeat() && !staleAutoRepeat &&
-                 !registered.binding.autoRepeat)) {
+                (event.isAutoRepeat() && !staleAutoRepeat && !registered.binding.autoRepeat)) {
                 continue;
             }
-            const auto match = std::find_if(
-                registered.binding.keyCombinations.cbegin(),
-                registered.binding.keyCombinations.cend(),
-                [&event, &registered](QKeyCombination combination) {
-                    return keyCombinationMatches(combination, event,
-                                                 registered.binding.allowedAdditionalModifiers);
-                });
+            const auto match = std::find_if(registered.binding.keyCombinations.cbegin(),
+                                            registered.binding.keyCombinations.cend(),
+                                            [&event, &registered](QKeyCombination combination) {
+                                                return keyCombinationMatches(
+                                                    combination, event,
+                                                    registered.binding.allowedAdditionalModifiers);
+                                            });
             if (match != registered.binding.keyCombinations.cend()) {
                 result.push_back(Candidate{registered.handle, registered.binding.priority,
                                            registered.order, *match});
@@ -318,8 +352,7 @@ struct WindowShortcutManager::Impl {
             }
             const auto match = std::find_if(
                 registered.activeReleaseCombinations.cbegin(),
-                registered.activeReleaseCombinations.cend(),
-                [&event](QKeyCombination combination) {
+                registered.activeReleaseCombinations.cend(), [&event](QKeyCombination combination) {
                     return releasedKeyEndsCombination(combination, event);
                 });
             if (match != registered.activeReleaseCombinations.cend()) {
@@ -335,18 +368,19 @@ struct WindowShortcutManager::Impl {
         if (candidates == nullptr) {
             return;
         }
-        std::stable_sort(candidates->begin(), candidates->end(), [](const Candidate& left,
-                                                                    const Candidate& right) {
-            if (left.priority != right.priority) {
-                return left.priority > right.priority;
-            }
-            return left.order < right.order;
-        });
+        std::stable_sort(candidates->begin(), candidates->end(),
+                         [](const Candidate& left, const Candidate& right) {
+                             if (left.priority != right.priority) {
+                                 return left.priority > right.priority;
+                             }
+                             return left.order < right.order;
+                         });
     }
 
     WindowShortcutManager& q;
     QList<QPointer<QWidget>> m_scopeWindows;
     QVector<RegisteredBinding> m_bindings;
+    QHash<int, PendingActivation> m_releaseActivations;
     QSet<int> m_heldKeys;
     QSet<int>& m_unreleasedKeys;
     QHash<int, quint64>& m_keyStateRevisions;
@@ -364,6 +398,10 @@ WindowShortcutManager::WindowShortcutManager(QObject* parent)
 }
 
 WindowShortcutManager::~WindowShortcutManager() {
+    auto& owners = applicationKeyState().releaseOwners;
+    for (auto it = owners.begin(); it != owners.end();) {
+        it = it.value() == this ? owners.erase(it) : std::next(it);
+    }
     if (QCoreApplication* application = QCoreApplication::instance()) {
         application->removeEventFilter(this);
     }
@@ -382,6 +420,11 @@ void WindowShortcutManager::addScopeWindow(QWidget* window) {
     }
     m_impl->m_scopeWindows.push_back(root);
     connect(root, &QObject::destroyed, this, [this]() {
+        for (auto& pending : m_impl->m_releaseActivations) {
+            if (!pending.scope) {
+                pending.handle = 0;
+            }
+        }
         m_impl->m_scopeWindows.erase(
             std::remove_if(m_impl->m_scopeWindows.begin(), m_impl->m_scopeWindows.end(),
                            [](const QPointer<QWidget>& item) { return item.isNull(); }),
@@ -391,12 +434,13 @@ void WindowShortcutManager::addScopeWindow(QWidget* window) {
 
 void WindowShortcutManager::removeScopeWindow(QWidget* window) {
     QWidget* root = window != nullptr ? window->window() : nullptr;
-    m_impl->m_scopeWindows.erase(
-        std::remove_if(m_impl->m_scopeWindows.begin(), m_impl->m_scopeWindows.end(),
-                       [root](const QPointer<QWidget>& item) {
-                           return item.isNull() || item == root;
-                       }),
-        m_impl->m_scopeWindows.end());
+    m_impl->cancelReleaseActivations(0, root);
+    m_impl->m_scopeWindows.erase(std::remove_if(m_impl->m_scopeWindows.begin(),
+                                                m_impl->m_scopeWindows.end(),
+                                                [root](const QPointer<QWidget>& item) {
+                                                    return item.isNull() || item == root;
+                                                }),
+                                 m_impl->m_scopeWindows.end());
 }
 
 WindowShortcutManager::InputSuspensionHandle WindowShortcutManager::suspendInput() {
@@ -418,8 +462,10 @@ void WindowShortcutManager::resumeInput(InputSuspensionHandle handle) {
 }
 
 WindowShortcutManager::BindingHandle WindowShortcutManager::addBinding(QObject* owner,
-                                                                        Binding binding) {
+                                                                       Binding binding) {
     if (owner == nullptr || !binding.activate ||
+        (binding.activationTrigger == Binding::ActivationTrigger::Release &&
+         (binding.release || binding.cancel || binding.autoRepeat)) ||
         static_cast<bool>(binding.release) != static_cast<bool>(binding.cancel)) {
         return 0;
     }
@@ -433,8 +479,8 @@ WindowShortcutManager::BindingHandle WindowShortcutManager::addBinding(QObject* 
     return handle;
 }
 
-bool WindowShortcutManager::setKeyCombinations(
-    BindingHandle handle, const QList<QKeyCombination>& keyCombinations) {
+bool WindowShortcutManager::setKeyCombinations(BindingHandle handle,
+                                               const QList<QKeyCombination>& keyCombinations) {
     const auto binding = std::find_if(
         m_impl->m_bindings.begin(), m_impl->m_bindings.end(),
         [handle](const Impl::RegisteredBinding& item) { return item.handle == handle; });
@@ -442,17 +488,23 @@ bool WindowShortcutManager::setKeyCombinations(
         return false;
     }
     binding->binding.keyCombinations = normalizedCombinations(keyCombinations);
+    m_impl->cancelReleaseActivations(handle);
     return true;
 }
 
 bool WindowShortcutManager::removeBinding(BindingHandle handle) {
+    m_impl->cancelReleaseActivations(handle);
+    if (const auto* registered = m_impl->findBinding(handle)) {
+        for (const auto combination : registered->activeReleaseCombinations) {
+            applicationKeyState().releaseOwners.remove(combination.key());
+        }
+    }
     const auto previousSize = m_impl->m_bindings.size();
-    m_impl->m_bindings.erase(
-        std::remove_if(m_impl->m_bindings.begin(), m_impl->m_bindings.end(),
-                       [handle](const Impl::RegisteredBinding& item) {
-                           return item.handle == handle;
-                       }),
-        m_impl->m_bindings.end());
+    m_impl->m_bindings.erase(std::remove_if(m_impl->m_bindings.begin(), m_impl->m_bindings.end(),
+                                            [handle](const Impl::RegisteredBinding& item) {
+                                                return item.handle == handle;
+                                            }),
+                             m_impl->m_bindings.end());
     return m_impl->m_bindings.size() != previousSize;
 }
 
@@ -500,16 +552,77 @@ bool WindowShortcutManager::eventFilter(QObject* watched, QEvent* event) {
         return QObject::eventFilter(watched, event);
     }
     if (event->type() == QEvent::Hide || event->type() == QEvent::WindowDeactivate) {
+        if (event->type() == QEvent::Hide) {
+            if (auto* widget = qobject_cast<QWidget*>(watched); widget && widget->isWindow()) {
+                m_impl->cancelReleaseActivations(0, widget);
+            }
+        }
         m_impl->noteScopeInputUnreachable(watched, event->type());
         return QObject::eventFilter(watched, event);
+    }
+    if (event->type() == QEvent::ApplicationDeactivate) {
+        m_impl->invalidateHeldKeys();
+        m_impl->cancelHeldBindings();
+        return false;
     }
     if (event->type() != QEvent::ShortcutOverride && event->type() != QEvent::KeyPress &&
         event->type() != QEvent::KeyRelease) {
         return QObject::eventFilter(watched, event);
     }
+    // QWidgetWindow forwards native input to the focused QWidget. Consuming
+    // that first delivery would bypass the scope and Qt's widget bookkeeping.
+    if (qobject_cast<QWindow*>(watched)) {
+        return false;
+    }
 
     auto* keyEvent = static_cast<QKeyEvent*>(event);
     const bool keyRelease = event->type() == QEvent::KeyRelease;
+    auto& releaseOwners = applicationKeyState().releaseOwners;
+    if (const auto owner = releaseOwners.value(keyEvent->key()); owner && owner != this) {
+        const auto pending = owner->m_impl->m_releaseActivations.constFind(keyEvent->key());
+        if (event->type() == QEvent::KeyPress && !keyEvent->isAutoRepeat() &&
+            pending != owner->m_impl->m_releaseActivations.cend() && pending->handle == 0) {
+            owner->m_impl->m_releaseActivations.remove(keyEvent->key());
+            releaseOwners.remove(keyEvent->key());
+        } else {
+            return false;
+        }
+    }
+    auto pending = m_impl->m_releaseActivations.find(keyEvent->key());
+    if (pending != m_impl->m_releaseActivations.end()) {
+        if (pending->handle == 0 && event->type() == QEvent::KeyPress &&
+            !keyEvent->isAutoRepeat()) {
+            m_impl->m_releaseActivations.erase(pending);
+            releaseOwners.remove(keyEvent->key());
+        } else {
+            event->accept();
+            if (!keyRelease || keyEvent->isAutoRepeat()) {
+                return true;
+            }
+            const auto activation = *pending;
+            m_impl->m_releaseActivations.erase(pending);
+            releaseOwners.remove(keyEvent->key());
+            m_impl->noteKeyRelease(*keyEvent);
+            auto* registered = m_impl->findBinding(activation.handle);
+            if (registered == nullptr || registered->owner == nullptr || !activation.scope ||
+                !activation.scope->isVisible() || m_impl->inputSuspended() ||
+                m_impl->scopeForReceiver(watched) == nullptr) {
+                return true;
+            }
+            const QPointer<WindowShortcutManager> guard(this);
+            const QPointer<QObject> owner = registered->owner;
+            const auto eligible = registered->binding.canActivate;
+            const auto activate = registered->binding.activate;
+            const ActivationContext context{watched, QApplication::focusWidget(), keyEvent,
+                                            activation.scope};
+            if ((!eligible || eligible(context)) && guard && owner &&
+                m_impl->findBinding(activation.handle)) {
+                static_cast<void>(activate(context));
+            }
+            // Activation may have destroyed this manager and the event receiver.
+            return true;
+        }
+    }
     if (keyRelease) {
         m_impl->noteKeyRelease(*keyEvent);
     } else if (event->type() == QEvent::KeyPress && !keyEvent->isAutoRepeat()) {
@@ -517,6 +630,18 @@ bool WindowShortcutManager::eventFilter(QObject* watched, QEvent* event) {
     }
     const QVector<Impl::Candidate> candidates =
         keyRelease ? m_impl->releaseCandidates(*keyEvent) : m_impl->candidates(*keyEvent);
+    if (!keyRelease || keyEvent->isAutoRepeat()) {
+        for (const auto& registered : m_impl->m_bindings) {
+            if (std::any_of(registered.activeReleaseCombinations.cbegin(),
+                            registered.activeReleaseCombinations.cend(),
+                            [keyEvent](auto combination) {
+                                return combination.key() == Qt::Key(keyEvent->key());
+                            })) {
+                event->accept();
+                return true;
+            }
+        }
+    }
     if (m_impl->inputSuspended()) {
         return QObject::eventFilter(watched, event);
     }
@@ -557,6 +682,9 @@ bool WindowShortcutManager::eventFilter(QObject* watched, QEvent* event) {
     }
 
     if (keyRelease) {
+        if (!keyEvent->isAutoRepeat()) {
+            releaseOwners.remove(keyEvent->key());
+        }
         // Once a held binding is armed, accept its physical release even if
         // focus moved to another top-level widget in the same process.
         bool handled = false;
@@ -583,8 +711,13 @@ bool WindowShortcutManager::eventFilter(QObject* watched, QEvent* event) {
             }
 
             const auto release = registered->binding.release;
+            const QPointer<WindowShortcutManager> guard(this);
             if (release && release(context)) {
                 handled = true;
+            }
+            if (!guard) {
+                event->accept();
+                return true;
             }
         }
         if (handled) {
@@ -615,6 +748,12 @@ bool WindowShortcutManager::eventFilter(QObject* watched, QEvent* event) {
         if (activate && keyEvent->isAutoRepeat()) {
             m_impl->noteKeyPress(*keyEvent);
         }
+        if (registered->binding.activationTrigger == Binding::ActivationTrigger::Release) {
+            m_impl->m_releaseActivations.insert(keyEvent->key(), {candidate.handle, scopeWindow});
+            releaseOwners.insert(keyEvent->key(), this);
+            event->accept();
+            return true;
+        }
         const quint64 pressRevision = m_impl->m_keyStateRevisions.value(keyEvent->key());
         // Arm before entering client code so a synchronous modal dialog,
         // deactivation, or physical release can end this hold immediately.
@@ -622,12 +761,19 @@ bool WindowShortcutManager::eventFilter(QObject* watched, QEvent* event) {
                            !registered->activeReleaseCombinations.contains(candidate.combination);
         if (armed) {
             registered->activeReleaseCombinations.push_back(candidate.combination);
+            releaseOwners.insert(keyEvent->key(), this);
         }
+        const QPointer<WindowShortcutManager> guard(this);
         const bool activated = activate && activate(context);
+        if (!guard) {
+            event->accept();
+            return true;
+        }
         if (!activated) {
             registered = m_impl->findBinding(candidate.handle);
             if (armed && registered != nullptr) {
                 registered->activeReleaseCombinations.removeAll(candidate.combination);
+                releaseOwners.remove(keyEvent->key());
             }
             // A declining handler must not consume another manager's recovery
             // evidence. Do not roll back any newer input/lifecycle transition

--- a/snow_shot/tests/close_release_native_test_support.h
+++ b/snow_shot/tests/close_release_native_test_support.h
@@ -1,0 +1,294 @@
+#ifndef SNOW_SHOT_CLOSE_RELEASE_NATIVE_TEST_SUPPORT_H
+#define SNOW_SHOT_CLOSE_RELEASE_NATIVE_TEST_SUPPORT_H
+
+#include <QApplication>
+#include <QElapsedTimer>
+#include <QPointer>
+#include <QKeyEvent>
+#include <QProcess>
+#include <QThread>
+#include <QWidget>
+
+#include <cstdlib>
+#include <iostream>
+#include <future>
+#include <stdexcept>
+
+#ifdef Q_OS_WIN
+#include <qt_windows.h>
+
+namespace close_release_native_test {
+constexpr UINT queryInput = WM_APP + 41;
+constexpr UINT resetInput = WM_APP + 42;
+constexpr UINT allowActivation = WM_APP + 43;
+constexpr UINT queryLastInput = WM_APP + 44;
+
+inline void require(bool condition, const char* message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+template <typename Action> int run(Action action) {
+    try {
+        action();
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+}
+
+inline void pump(int milliseconds) {
+    QElapsedTimer timer;
+    timer.start();
+    do {
+        QApplication::processEvents(QEventLoop::AllEvents, 10);
+        QThread::msleep(1);
+    } while (timer.elapsed() < milliseconds);
+}
+
+inline void activate(HWND window) {
+    const DWORD current = GetCurrentThreadId();
+    const DWORD foreground = GetWindowThreadProcessId(GetForegroundWindow(), nullptr);
+    const bool attached = foreground && foreground != current &&
+                          AttachThreadInput(current, foreground, TRUE) != FALSE;
+    SetForegroundWindow(window);
+    BringWindowToTop(window);
+    if (attached) {
+        AttachThreadInput(current, foreground, FALSE);
+    }
+}
+
+inline LRESULT CALLBACK receiverProcedure(HWND window, UINT message, WPARAM wParam, LPARAM lParam) {
+    static int received = 0;
+    static UINT lastInput = 0;
+    switch (message) {
+    case queryInput:
+        return received;
+    case queryLastInput:
+        return lastInput;
+    case resetInput:
+        received = 0;
+        return 0;
+    case allowActivation:
+        return AllowSetForegroundWindow(static_cast<DWORD>(wParam));
+    case WM_KEYDOWN:
+    case WM_KEYUP:
+    case WM_SYSKEYDOWN:
+    case WM_SYSKEYUP:
+    case WM_LBUTTONUP:
+    case WM_RBUTTONUP:
+    case WM_MBUTTONUP:
+    case WM_NCLBUTTONUP:
+    case WM_NCRBUTTONUP:
+    case WM_NCMBUTTONUP:
+    case WM_CONTEXTMENU:
+        ++received;
+        lastInput = message;
+        return 0;
+    case WM_DESTROY:
+        QCoreApplication::quit();
+        return 0;
+    default:
+        return DefWindowProcW(window, message, wParam, lParam);
+    }
+}
+
+inline bool receiverRequested() {
+    return qApp->arguments().contains(QStringLiteral("--close-release-receiver"));
+}
+
+inline int runReceiver() {
+    WNDCLASSW cls{};
+    cls.lpfnWndProc = receiverProcedure;
+    cls.hInstance = GetModuleHandleW(nullptr);
+    cls.lpszClassName = L"SnowCloseReleaseReceiver";
+    require(RegisterClassW(&cls) != 0, "register native receiver");
+    const HWND window =
+        CreateWindowExW(0, cls.lpszClassName, L"Snow Shot input release test", WS_OVERLAPPEDWINDOW,
+                        50, 50, 900, 700, nullptr, nullptr, cls.hInstance, nullptr);
+    require(window != nullptr, "create receiver window");
+    ShowWindow(window, SW_SHOW);
+    std::cout << "receiver=" << reinterpret_cast<quintptr>(window) << std::endl;
+    return qApp->exec();
+}
+
+class Receiver final {
+  public:
+    Receiver() {
+        process.start(QCoreApplication::applicationFilePath(),
+                      {QStringLiteral("--close-release-receiver"), QStringLiteral("-platform"),
+                       QStringLiteral("windows")});
+        require(process.waitForStarted(3000), "start separate input receiver process");
+        QByteArray output;
+        QElapsedTimer timer;
+        timer.start();
+        while (!window && timer.elapsed() < 5000) {
+            static_cast<void>(process.waitForReadyRead(50));
+            output += process.readAllStandardOutput();
+            const auto start = output.indexOf("receiver=");
+            if (start >= 0 && output.indexOf('\n', start) >= 0) {
+                const auto value = output.mid(start + 9).split('\n').first().trimmed();
+                window = reinterpret_cast<HWND>(value.toULongLong());
+            }
+        }
+        require(window && IsWindow(window), "receiver must publish its HWND");
+    }
+
+    ~Receiver() {
+        PostMessageW(window, WM_CLOSE, 0, 0);
+        if (!process.waitForFinished(2000)) {
+            process.kill();
+            static_cast<void>(process.waitForFinished(2000));
+        }
+    }
+
+    // Test-only SendInput exercises actual routing across process boundaries.
+    // No input synthesis is used by the production close-on-release implementation.
+    static void key(bool up) {
+        INPUT input{};
+        input.type = INPUT_KEYBOARD;
+        input.ki.wVk = VK_ESCAPE;
+        input.ki.dwFlags = up ? KEYEVENTF_KEYUP : 0;
+        require(SendInput(1, &input, sizeof(input)) == 1, "send native Escape input");
+    }
+
+    static void mouse(Qt::MouseButton button, bool up) {
+        INPUT input{};
+        input.type = INPUT_MOUSE;
+        input.mi.dwFlags =
+            button == Qt::LeftButton    ? (up ? MOUSEEVENTF_LEFTUP : MOUSEEVENTF_LEFTDOWN)
+            : button == Qt::RightButton ? (up ? MOUSEEVENTF_RIGHTUP : MOUSEEVENTF_RIGHTDOWN)
+                                        : (up ? MOUSEEVENTF_MIDDLEUP : MOUSEEVENTF_MIDDLEDOWN);
+        require(SendInput(1, &input, sizeof(input)) == 1, "send native mouse input");
+    }
+
+    void verify(QWidget& target, Qt::MouseButton button = Qt::NoButton, bool doubleClick = false,
+                bool caption = false) {
+        std::cerr << "Verifying native dismissal: button=" << static_cast<int>(button)
+                  << " double-click=" << doubleClick << '\n';
+        struct Observer final : QObject {
+            QStringList events;
+            Observer() {
+                qApp->installEventFilter(this);
+            }
+            ~Observer() override {
+                qApp->removeEventFilter(this);
+            }
+            bool eventFilter(QObject* receiver, QEvent* event) override {
+                if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease ||
+                    event->type() == QEvent::MouseButtonPress ||
+                    event->type() == QEvent::MouseButtonRelease ||
+                    event->type() == QEvent::ApplicationDeactivate) {
+                    events.append(QStringLiteral("%1:%2")
+                                      .arg(receiver->metaObject()->className())
+                                      .arg(static_cast<int>(event->type())));
+                    if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease) {
+                        const auto* key = static_cast<QKeyEvent*>(event);
+                        events.last() += QStringLiteral("/key=%1/repeat=%2")
+                                             .arg(key->key())
+                                             .arg(key->isAutoRepeat());
+                    }
+                }
+                return false;
+            }
+        } observer;
+        QPointer<QWidget> guarded(&target);
+        const HWND targetWindow = reinterpret_cast<HWND>(target.winId());
+        RECT bounds{};
+        require(GetWindowRect(targetWindow, &bounds) != FALSE, "get target rectangle");
+        SetWindowPos(window, HWND_NOTOPMOST, bounds.left - 50, bounds.top - 50,
+                     bounds.right - bounds.left + 100, bounds.bottom - bounds.top + 100,
+                     SWP_NOACTIVATE);
+        AllowSetForegroundWindow(static_cast<DWORD>(process.processId()));
+        activate(window);
+        pump(30);
+        SendMessageW(window, allowActivation, GetCurrentProcessId(), 0);
+        target.activateWindow();
+        target.raise();
+        activate(targetWindow);
+        pump(100);
+        require(GetForegroundWindow() == targetWindow, "dismissal target must own foreground");
+        SendMessageW(window, resetInput, 0, 0);
+        if (button == Qt::NoButton) {
+            key(false);
+            pump(40);
+            const bool visibleAfterPress = guarded && guarded->isVisible();
+            key(false);
+            pump(40);
+            const bool visibleAfterRepeat = guarded && guarded->isVisible();
+            key(true);
+            require(visibleAfterPress && visibleAfterRepeat,
+                    "native key down/repeat must not dismiss");
+        } else {
+            const int x = (bounds.left + bounds.right) / 2;
+            const int y = (bounds.top + bounds.bottom) / 2;
+            require(SetCursorPos(x, y) != FALSE, "position pointer over target");
+            pump(30);
+            if (caption) {
+                require(SendMessageW(targetWindow, WM_NCHITTEST, 0, MAKELPARAM(x, y)) == HTCAPTION,
+                        "pinned gesture must exercise its native caption");
+            }
+            const auto click = [&] {
+                // A caption down can enter USER32's synchronous move loop.
+                // Release from another thread so that loop cannot block its own
+                // test driver. Observe visibility while the button is still held.
+                auto released = std::async(std::launch::async, [=] {
+                    Sleep(60);
+                    const bool visible = IsWindow(targetWindow) && IsWindowVisible(targetWindow);
+                    mouse(button, true);
+                    return visible;
+                });
+                mouse(button, false);
+                pump(70);
+                require(released.get(), "native button down must not dismiss");
+            };
+            if (doubleClick) {
+                click();
+            }
+            click();
+        }
+        QElapsedTimer timer;
+        timer.start();
+        while (guarded && guarded->isVisible() && timer.elapsed() < 5000) {
+            pump(10);
+        }
+        if (guarded && guarded->isVisible()) {
+            std::cerr << "Input trace: " << observer.events.join(QStringLiteral(", ")).toStdString()
+                      << " foreground=" << GetForegroundWindow() << " target=" << targetWindow
+                      << " focus="
+                      << (QApplication::focusWidget()
+                              ? QApplication::focusWidget()->metaObject()->className()
+                              : "none")
+                      << " receiver-input=" << SendMessageW(window, queryInput, 0, 0) << '\n';
+        }
+        require(!guarded || !guarded->isVisible(), "native release must dismiss target");
+        pump(100);
+        if (SendMessageW(window, queryInput, 0, 0) != 0) {
+            std::cerr << "Leaked input: button=" << static_cast<int>(button)
+                      << " count=" << SendMessageW(window, queryInput, 0, 0)
+                      << " last=" << SendMessageW(window, queryLastInput, 0, 0)
+                      << " trace=" << observer.events.join(QStringLiteral(", ")).toStdString()
+                      << '\n';
+        }
+        require(SendMessageW(window, queryInput, 0, 0) == 0,
+                "dismissal input leaked into the separate receiver process");
+        activate(window);
+        pump(50);
+        require(GetForegroundWindow() == window, "receiver must regain foreground");
+        key(false);
+        key(true);
+        pump(80);
+        require(SendMessageW(window, queryInput, 0, 0) >= 2,
+                "next independent input must reach the receiver normally");
+    }
+
+  private:
+    QProcess process;
+    HWND window = nullptr;
+};
+} // namespace close_release_native_test
+#endif
+
+#endif

--- a/snow_shot/tests/mouse_release_action_tests.cpp
+++ b/snow_shot/tests/mouse_release_action_tests.cpp
@@ -1,0 +1,130 @@
+#include "snow_shot/presentation/mousereleaseactioncontroller.h"
+
+#include <QApplication>
+#include <QContextMenuEvent>
+#include <QMouseEvent>
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+
+namespace {
+using snow_shot::presentation::MouseReleaseActionController;
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        std::cerr << message << '\n';
+        std::exit(1);
+    }
+}
+
+void release(QWidget& receiver, Qt::MouseButton button, QPointF point = {10, 10}) {
+    QMouseEvent event(QEvent::MouseButtonRelease, point, point, button, Qt::NoButton,
+                      Qt::NoModifier);
+    QCoreApplication::sendEvent(&receiver, &event);
+}
+
+void completesAfterReleaseDispatch() {
+    QWidget window;
+    window.resize(100, 100);
+    window.show();
+    QApplication::processEvents();
+    MouseReleaseActionController controller;
+    int closes = 0;
+    require(controller.arm(&window, Qt::RightButton, [&] { ++closes; }), "arm right close");
+    require(closes == 0 && window.isVisible(), "arming must keep the window visible");
+    require(!controller.arm(&window, Qt::MiddleButton, [&] { closes += 100; }),
+            "another action cannot replace an owned gesture");
+    release(window, Qt::LeftButton);
+    require(closes == 0 && controller.pending(), "unrelated release must not complete");
+    release(window, Qt::RightButton, {-100, 200});
+    require(closes == 0, "action must wait until release dispatch returns");
+    QContextMenuEvent context(QContextMenuEvent::Mouse, {10, 10}, {10, 10});
+    context.ignore();
+    QCoreApplication::sendEvent(&window, &context);
+    require(context.isAccepted(), "dismissing right-click must not open a context menu");
+    QApplication::processEvents();
+    require(closes == 1 && !controller.pending() && !QWidget::mouseGrabber(),
+            "outside release must complete once and release capture");
+    release(window, Qt::RightButton);
+    QApplication::processEvents();
+    require(closes == 1, "duplicate release must not execute again");
+    require(controller.arm(&window, Qt::MiddleButton, [&] { ++closes; }), "arm next gesture");
+    release(window, Qt::MiddleButton);
+    QApplication::processEvents();
+    require(closes == 2, "next independent gesture must work");
+}
+
+void interruptionsDiscardPendingAndQueuedActions() {
+    for (int scenario = 0; scenario != 5; ++scenario) {
+        QWidget window;
+        window.show();
+        QApplication::processEvents();
+        MouseReleaseActionController controller;
+        int closes = 0;
+        require(controller.arm(&window, Qt::RightButton, [&] { ++closes; }), "arm interruption");
+        switch (scenario) {
+        case 0:
+            window.hide();
+            break;
+        case 1: {
+            QEvent deactivate(QEvent::ApplicationDeactivate);
+            QCoreApplication::sendEvent(qApp, &deactivate);
+            break;
+        }
+        case 2: {
+            QEvent ungrab(QEvent::UngrabMouse);
+            QCoreApplication::sendEvent(&window, &ungrab);
+            break;
+        }
+        case 3:
+            release(window, Qt::RightButton);
+            controller.cancel();
+            break;
+        case 4:
+            controller.cancel();
+            break;
+        }
+        release(window, Qt::RightButton);
+        QApplication::processEvents();
+        require(closes == 0 && !controller.pending(), "interrupted gesture must never close later");
+    }
+}
+
+void captureAndCallbackLifetimesAreRespected() {
+    QWidget window;
+    QWidget other;
+    window.show();
+    other.show();
+    QApplication::processEvents();
+    MouseReleaseActionController lifetime;
+    int closes = 0;
+    auto retiring = std::make_unique<QWidget>();
+    retiring->show();
+    QApplication::processEvents();
+    require(lifetime.arm(retiring.get(), Qt::RightButton, [&] { ++closes; }), "arm retiring scope");
+    release(*retiring, Qt::RightButton);
+    retiring.reset();
+    QApplication::processEvents();
+    require(closes == 0 && !lifetime.pending(), "scope destruction must cancel queued closing");
+    auto controller = std::make_unique<MouseReleaseActionController>();
+    other.grabMouse();
+    require(!controller->arm(&window, Qt::LeftButton, [] {}),
+            "must not steal another window's capture");
+    require(QWidget::mouseGrabber() == &other, "unrelated capture must remain owned");
+    other.releaseMouse();
+    require(controller->arm(&window, Qt::LeftButton, [&] { controller.reset(); }),
+            "arm destructive callback");
+    release(window, Qt::LeftButton);
+    QApplication::processEvents();
+    require(!controller && !QWidget::mouseGrabber(), "callback may destroy its controller");
+}
+} // namespace
+
+int main(int argc, char** argv) {
+    QApplication application(argc, argv);
+    completesAfterReleaseDispatch();
+    interruptionsDiscardPendingAndQueuedActions();
+    captureAndCallbackLifetimesAreRespected();
+    return 0;
+}

--- a/snow_shot/tests/screen_recording_shortcut_tests.cpp
+++ b/snow_shot/tests/screen_recording_shortcut_tests.cpp
@@ -1,3 +1,4 @@
+#include "close_release_native_test_support.h"
 #include "snow_shot/presentation/screenrecordingareawindow.h"
 #include "snow_shot/presentation/screenrecordingshortcutcontroller.h"
 #include "snow_shot/presentation/screenrecordingtoolbarwindow.h"
@@ -339,6 +340,16 @@ void recordingControlShortcutsFollowButtonsAndSettings() {
     area.show();
     toolbar.show();
     focus(toolbar);
+    QKeyEvent closePress(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+    QApplication::sendEvent(&toolbar, &closePress);
+    require(ends == 0 && toolbar.isVisible(), "recording must stay open while Escape is held");
+    QKeyEvent closeRepeat(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier, QString(), true);
+    QApplication::sendEvent(&toolbar, &closeRepeat);
+    require(ends == 0, "held Escape must not end recording");
+    QKeyEvent closeRelease(QEvent::KeyRelease, Qt::Key_Escape, Qt::NoModifier);
+    QApplication::sendEvent(&toolbar, &closeRelease);
+    require(ends == 1, "Escape release must end recording once");
+    ends = 0;
     pressAll(toolbar);
     require(starts == 1 && ends == 1 && exports == 0 && copies == 0 && pauses == 0 && resumes == 0,
             "idle shortcuts must only start or end the recording session");
@@ -654,6 +665,12 @@ void recordingShortcutsFollowBothWindowsAndConfiguredKeys() {
 
 int main(int argc, char* argv[]) {
     QApplication app(argc, argv);
+#ifdef Q_OS_WIN
+    if (close_release_native_test::receiverRequested()) {
+        return close_release_native_test::runReceiver();
+    }
+#endif
+
     QTemporaryDir temporary;
     require(temporary.isValid(), "isolated test storage must be available");
     const QString executableDirectory = QDir(temporary.path()).filePath(QStringLiteral("bin"));
@@ -661,6 +678,29 @@ int main(int argc, char* argv[]) {
     auto& storage = snow_shot::storage::ApplicationStorage::instance();
     require(storage.initialize({executableDirectory, temporary.path(), 60000}).success,
             "isolated recording shortcut settings must initialize");
+#ifdef Q_OS_WIN
+    if (app.arguments().contains(QStringLiteral("--close-release-native"))) {
+        const int result = close_release_native_test::run([&] {
+            close_release_native_test::Receiver receiver;
+            ScreenRecordingAreaWindow area;
+            ScreenRecordingToolbarWindow toolbar;
+            area.setPhysicalRegion(QRect(150, 150, 500, 350));
+            auto controller = std::make_unique<ScreenRecordingShortcutController>(area, toolbar);
+            QObject::connect(toolbar.palette(), &ScreenshotToolPalette::recordingCloseRequested,
+                             &area, [&] {
+                                 controller.reset();
+                                 toolbar.hide();
+                                 area.hide();
+                             });
+            area.show();
+            toolbar.showAndActivate();
+            receiver.verify(toolbar);
+            require(!controller && !area.isVisible(), "recording teardown must follow release");
+        });
+        storage.shutdown();
+        return result;
+    }
+#endif
     recordingToolbarTakesFocusWhenOpenedOrStarted();
     recordingToolbarKeepsFocusAfterEditingAndSurfaceRestoration();
     recordingSelectionEditsAnnotationsAndPreservesPassThrough();

--- a/snow_shot/tests/screenshot_canvas_renderer_tests.cpp
+++ b/snow_shot/tests/screenshot_canvas_renderer_tests.cpp
@@ -1,3 +1,5 @@
+#include "snow_shot/presentation/windowshortcutmanager.h"
+#include "close_release_native_test_support.h"
 #include "snow_shot/presentation/screenshotcanvasrenderer.h"
 #include "snow_shot/presentation/directcapturehistory.h"
 #include "snow_shot/presentation/screenshothistoryservice.h"
@@ -79,6 +81,11 @@ QImage testRenderOcrFilteredImage(const QImage& source, const QRectF& canvasRect
 
 class NoopOverlayEventSink final : public ScreenshotOverlayEventSink {
   public:
+    ScreenshotOverlayRightClickResult rightClickResult = ScreenshotOverlayRightClickResult::Ignored;
+    std::function<void()> cancel = [] {};
+    void completeRightClickCancellation() override {
+        cancel();
+    }
     bool shouldHandleOverlayMouseEvent(const ScreenshotOverlayWindow*, const QPointF&,
                                        bool) const override {
         return false;
@@ -90,8 +97,9 @@ class NoopOverlayEventSink final : public ScreenshotOverlayEventSink {
 
     void handleOverlayMouseRelease(ScreenshotOverlayWindow*, const QPointF&) override {}
 
-    bool handleOverlayRightClick(ScreenshotOverlayWindow*, const QPointF&) override {
-        return false;
+    ScreenshotOverlayRightClickResult handleOverlayRightClick(ScreenshotOverlayWindow*,
+                                                              const QPointF&) override {
+        return rightClickResult;
     }
 
     bool handleOverlayWheel(ScreenshotOverlayWindow*, const QPointF&, const QPoint&,
@@ -3691,10 +3699,79 @@ void resettingDisplaySessionEditingStateResetsEveryCanvas() {
                 reusableCanvas->canvasTool() == SnowCanvasTool::Select,
             "resetting display editing state must include active and reusable canvases");
 }
+void overlayRightClickClosesOnRelease(bool native = false) {
+    using namespace snow_shot::presentation;
+    NoopOverlayEventSink sink;
+    sink.rightClickResult = ScreenshotOverlayRightClickResult::CancelCapture;
+    ScreenshotOverlayWindow overlay(sink, new SnowCanvasWidget);
+    overlay.resize(500, 350);
+    overlay.move(150, 150);
+    QImage background(500, 350, QImage::Format_ARGB32_Premultiplied);
+    background.fill(Qt::white);
+    overlay.setScreenshotImage(background, QRectF(background.rect()));
+    require(overlay.canvas()->setViewportCamera(250.0, 175.0, 1.0),
+            "initialize screenshot camera for native hit testing");
+    sink.cancel = [&] { overlay.hide(); };
+    overlay.show();
+    QApplication::processEvents();
+#ifdef Q_OS_WIN
+    if (native) {
+        close_release_native_test::Receiver receiver;
+        receiver.verify(overlay, Qt::RightButton);
+        overlay.show();
+        WindowShortcutManager manager;
+        manager.addScopeWindow(&overlay);
+        WindowShortcutManager::Binding cancel;
+        cancel.id = QStringLiteral("overlay.cancel.native-test");
+        cancel.keyCombinations = {QKeyCombination(Qt::NoModifier, Qt::Key_Escape)};
+        cancel.activationTrigger = WindowShortcutManager::Binding::ActivationTrigger::Release;
+        cancel.activate = [&](const auto&) {
+            overlay.hide();
+            return true;
+        };
+        require(manager.addBinding(&overlay, cancel) != 0, "register overlay native Escape");
+        receiver.verify(overlay);
+        return;
+    }
+#else
+    Q_UNUSED(native)
+#endif
+    auto* canvas = overlay.canvas();
+    QMouseEvent press(QEvent::MouseButtonPress, QPointF(50, 50), QPointF(200, 200), Qt::RightButton,
+                      Qt::RightButton, Qt::NoModifier);
+    QApplication::sendEvent(canvas, &press);
+    QApplication::processEvents();
+    require(overlay.isVisible(), "right press must leave screenshot overlay visible");
+    QMouseEvent release(QEvent::MouseButtonRelease, QPointF(-10, -10), QPointF(140, 140),
+                        Qt::RightButton, Qt::NoButton, Qt::NoModifier);
+    QApplication::sendEvent(&overlay, &release);
+    require(overlay.isVisible(), "close must wait until release dispatch finishes");
+    QApplication::processEvents();
+    require(!overlay.isVisible(), "right release must close screenshot overlay");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
     QApplication application(argc, argv);
+#ifdef Q_OS_WIN
+    if (close_release_native_test::receiverRequested()) {
+        return close_release_native_test::runReceiver();
+    }
+#endif
+
+    if (application.arguments().contains(QStringLiteral("--close-release-only")) ||
+        application.arguments().contains(QStringLiteral("--close-release-native"))) {
+#ifdef Q_OS_WIN
+        return close_release_native_test::run([&] {
+            overlayRightClickClosesOnRelease(
+                application.arguments().contains(QStringLiteral("--close-release-native")));
+        });
+#else
+        overlayRightClickClosesOnRelease();
+        return 0;
+#endif
+    }
     if (application.arguments().contains(QStringLiteral("--direct-capture-history-rendering"))) {
         directCaptureHistoryUsesTheEditorCoordinateSystem();
         return 0;

--- a/snow_shot/tests/screenshot_history_tests.cpp
+++ b/snow_shot/tests/screenshot_history_tests.cpp
@@ -859,7 +859,8 @@ void historyKeysOnlyWorkDuringSelectionStates() {
     require(selectionConfirmedCount == 1,
             "confirming manual selection did not notify post-selection actions");
 
-    require(handler.handleRightClick(nullptr, QPointF(4, 4)),
+    require((handler.handleRightClick(nullptr, QPointF(4, 4)) ==
+             ScreenshotOverlayRightClickResult::Handled),
             "right-click did not handle manual selection");
     require(returnToCurrentCount == 1,
             "right-click did not check for an active historical screenshot");
@@ -867,7 +868,8 @@ void historyKeysOnlyWorkDuringSelectionStates() {
             "ordinary right-click did not return to intelligent selection");
 
     hasCurrentScreenshot = true;
-    require(handler.handleRightClick(nullptr, QPointF(4, 4)),
+    require((handler.handleRightClick(nullptr, QPointF(4, 4)) ==
+             ScreenshotOverlayRightClickResult::Handled),
             "right-click did not handle historical selection");
     require(returnToCurrentCount == 2,
             "historical right-click did not return to the current screenshot");
@@ -1052,7 +1054,8 @@ void manualSelectionUsesSharedMarqueeTransaction() {
     handler.handleMousePress(nullptr, QPointF(10, 10));
     handler.handleMouseMove(nullptr, QPointF(30, 40));
     handler.handleMouseRelease(nullptr, QPointF(30, 40));
-    require(handler.handleRightClick(nullptr, {}) && handler.handleWheel(nullptr, {}, {0, 120}, {}),
+    require((handler.handleRightClick(nullptr, {}) == ScreenshotOverlayRightClickResult::Handled) &&
+                handler.handleWheel(nullptr, {}, {0, 120}, {}),
             "external drags must consume ordinary right-click and wheel commands");
     handler.handleUnhandledMiddleClick();
     handler.handleUnhandledLeftDoubleClick();
@@ -1820,6 +1823,7 @@ void configuredScreenshotShortcutsControlMoveAndCursorNavigation() {
     ScreenshotInteractionState interaction;
     interaction.confirmSelection();
     QWidget shortcutWindow;
+    shortcutWindow.show();
     QWidget colorPickerToolWindow;
     snow_shot::presentation::WindowShortcutManager shortcutManager;
     shortcutManager.addScopeWindow(&shortcutWindow);
@@ -1945,6 +1949,7 @@ void configuredScreenshotShortcutsControlMoveAndCursorNavigation() {
 
     require(dispatchShortcut(shortcutWindow, Qt::Key_F, Qt::ControlModifier) &&
                 dispatchShortcut(shortcutWindow, Qt::Key_Escape) &&
+                dispatchShortcutRelease(shortcutWindow, Qt::Key_Escape) &&
                 dispatchShortcut(shortcutWindow, Qt::Key_C, Qt::ControlModifier) &&
                 dispatchShortcut(shortcutWindow, Qt::Key_Z, Qt::ControlModifier) &&
                 dispatchShortcut(shortcutWindow, Qt::Key_Y, Qt::ControlModifier) &&
@@ -2007,12 +2012,13 @@ void configuredScreenshotShortcutsControlMoveAndCursorNavigation() {
             "custom toolbar bindings must remove every default shortcut");
     require(dispatchShortcut(shortcutWindow, Qt::Key_F, Qt::AltModifier) &&
                 dispatchShortcut(shortcutWindow, Qt::Key_Escape, Qt::AltModifier) &&
+                dispatchShortcutRelease(shortcutWindow, Qt::Key_Escape) &&
                 dispatchShortcut(shortcutWindow, Qt::Key_C, Qt::AltModifier) &&
                 dispatchShortcut(shortcutWindow, Qt::Key_Z, Qt::AltModifier) &&
                 dispatchShortcut(shortcutWindow, Qt::Key_Y, Qt::AltModifier) &&
                 pinActivations == 2 && cancelActivations == 2 && copyActivations == 2 &&
                 undoActivations == 2 && redoActivations == 2,
-            "custom toolbar bindings must invoke the same commands immediately");
+            "custom toolbar bindings must invoke commands at their configured phase");
 
     // Recognition presents an independent top-level surface, but it remains
     // part of the screenshot session. Screenshot and drawing commands must
@@ -2030,6 +2036,7 @@ void configuredScreenshotShortcutsControlMoveAndCursorNavigation() {
     shortcutManager.addScopeWindow(&recognitionWindow);
     require(dispatchShortcut(recognitionWindow, Qt::Key_F, Qt::AltModifier) &&
                 dispatchShortcut(recognitionWindow, Qt::Key_Escape, Qt::AltModifier) &&
+                dispatchShortcutRelease(recognitionWindow, Qt::Key_Escape) &&
                 dispatchShortcut(recognitionWindow, Qt::Key_C, Qt::AltModifier) &&
                 pinActivations == 3 && cancelActivations == 3 && copyActivations == 3,
             "screenshot commands must remain available from a focused recognition surface");
@@ -2047,6 +2054,31 @@ void configuredScreenshotShortcutsControlMoveAndCursorNavigation() {
             "restored cursor shortcut was not handled");
     require(cursorMoves == QVector<PhysicalCursorDirection>{PhysicalCursorDirection::Up},
             "restored cursor shortcut must use the persisted configuration");
+}
+
+void rightClickSeparatesDismissalFromSelectionChanges() {
+    ScreenshotCaptureState captureState;
+    ScreenshotDisplaySession displays;
+    ScreenshotGeometryMapper geometry;
+    ScreenshotSelectionModel selection;
+    ScreenshotIntelligentSelectionModel intelligent;
+    ScreenshotInteractionState interaction;
+    interaction.enterOverlayVisible(true);
+    int cancels = 0;
+    ScreenshotOverlayInputActions actions;
+    actions.cancelCapture = [&] { ++cancels; };
+    ScreenshotOverlayInputHandler handler(
+        {captureState, interaction, selection, intelligent, geometry, displays, actions});
+    require(handler.handleRightClick(nullptr, {}) ==
+                    ScreenshotOverlayRightClickResult::CancelCapture &&
+                cancels == 0,
+            "intelligent selection right press must only request deferred cancellation");
+    handler.completeRightClickCancellation();
+    require(cancels == 1, "release completion must execute capture cancellation");
+    handler.armCanvasColorSampling();
+    require(handler.handleRightClick(nullptr, {}) == ScreenshotOverlayRightClickResult::Handled &&
+                cancels == 1,
+            "color sampling cancellation must not dismiss the overlay");
 }
 
 void scrollingCaptureRoutesEveryToolbarShortcut() {
@@ -2074,6 +2106,7 @@ void scrollingCaptureRoutesEveryToolbarShortcut() {
     ScreenshotIntelligentSelectionModel intelligent;
     ScreenshotInteractionState interaction;
     QWidget window;
+    window.show();
     snow_shot::presentation::WindowShortcutManager manager;
     manager.addScopeWindow(&window);
     QStringList dispatched;
@@ -2101,12 +2134,25 @@ void scrollingCaptureRoutesEveryToolbarShortcut() {
         require(settings.setAllShortcutsAtomic(shortcuts), "failed to bind toolbar command");
         interaction.enterScrollingCapture();
         dispatched.clear();
-        require(dispatchShortcut(window, Qt::Key_F12, Qt::ControlModifier | Qt::AltModifier) &&
-                    dispatched == QStringList{command},
+        require(dispatchShortcut(window, Qt::Key_F12, Qt::ControlModifier | Qt::AltModifier),
+                "toolbar command must accept its trigger");
+        if (command == QStringLiteral("cancel_screenshot")) {
+            require(dispatched.isEmpty(), "screenshot cancel must wait for release");
+            require(dispatchShortcutRelease(window, Qt::Key_F12),
+                    "cancel release must be consumed");
+        }
+        require(dispatched == QStringList{command},
                 "every scrolling toolbar shortcut must invoke the common command exactly once");
         commandEnabled = false;
-        require(!dispatchShortcut(window, Qt::Key_F12, Qt::ControlModifier | Qt::AltModifier) &&
-                    dispatched.size() == 1,
+        const bool accepted =
+            dispatchShortcut(window, Qt::Key_F12, Qt::ControlModifier | Qt::AltModifier);
+        if (command == QStringLiteral("cancel_screenshot")) {
+            require(accepted && dispatchShortcutRelease(window, Qt::Key_F12),
+                    "a reserved release stays consumed even when the action declines");
+        } else {
+            require(!accepted, "a declined press action must remain unhandled");
+        }
+        require(dispatched.size() == 1,
                 "a declined toolbar command must not be replaced by a shortcut implementation");
         commandEnabled = true;
         inputAllowed = false;
@@ -2353,8 +2399,9 @@ void canvasColorSamplingConsumesOneCanvasClick() {
     handler.resetTransientShortcuts();
 
     handler.armCanvasColorSampling();
-    require(handler.handleRightClick(nullptr, QPointF(12, 16)) && sampleCount == 1 &&
-                cancelCount == 1,
+    require((handler.handleRightClick(nullptr, QPointF(12, 16)) ==
+             ScreenshotOverlayRightClickResult::Handled) &&
+                sampleCount == 1 && cancelCount == 1,
             "right-click must cancel an armed canvas sampler without sampling");
     handler.armCanvasColorSampling();
     handler.resetTransientShortcuts();
@@ -2417,6 +2464,7 @@ int main(int argc, char** argv) {
         return 0;
     }
     if (QCoreApplication::arguments().contains(QStringLiteral("--shortcut-input-only"))) {
+        rightClickSeparatesDismissalFromSelectionChanges();
         scrollingCaptureRoutesEveryToolbarShortcut();
         externalSelectionSupportsHeldShortcuts();
         colorCopyEndsCaptureOnlyAfterSuccessfulCopy();

--- a/snow_shot/tests/screenshot_pinned_window_tests.cpp
+++ b/snow_shot/tests/screenshot_pinned_window_tests.cpp
@@ -1,3 +1,4 @@
+#include "close_release_native_test_support.h"
 #include "snow_shot/presentation/screenshotpinnedwindow.h"
 #include "snow_shot/presentation/canvasstatusreadout.h"
 #include "../src/presentation/pinned/screenshotpinnedwindownative.h"
@@ -257,6 +258,13 @@ void waitForUi(int milliseconds) {
         QCoreApplication::processEvents(QEventLoop::AllEvents, 20);
         QThread::msleep(1);
     }
+}
+
+void releaseCloseGesture(QWidget& receiver, Qt::MouseButton button) {
+    const QPoint point = receiver.rect().center();
+    QMouseEvent release(QEvent::MouseButtonRelease, QPointF(point),
+                        QPointF(receiver.mapToGlobal(point)), button, Qt::NoButton, Qt::NoModifier);
+    QCoreApplication::sendEvent(&receiver, &release);
 }
 
 void sendShortcut(QWidget& receiver, Qt::Key key, Qt::KeyboardModifiers modifiers = Qt::NoModifier,
@@ -3186,6 +3194,8 @@ void pinnedMiddleClickActions() {
     {
         press(canvas);
     }
+    require(guarded && guarded->isVisible(), "middle-click press must keep the pin open");
+    releaseCloseGesture(*window, Qt::MiddleButton);
     require(processUntilDeleted(guarded, 2000), "middle-click Close must delete the pin");
     require(offscreen || removed, "middle-click Close must use the persistence removal lifecycle");
 }
@@ -3225,6 +3235,8 @@ void pinnedOffscreenDoubleClickActions() {
     require(guarded && !thumbnail->isChecked(), "offscreen None must leave the window unchanged");
     require(settings.setDoubleClickAction(QStringLiteral("close")), "configure offscreen Close");
     send(canvas);
+    require(guarded && guarded->isVisible(), "double-click must wait for its second release");
+    releaseCloseGesture(*window, Qt::LeftButton);
     require(processUntilDeleted(guarded, 2000), "offscreen Close must delete the clicked window");
 }
 
@@ -3308,6 +3320,8 @@ void pinnedOcrDoubleClickUsesDragRegion(bool middleClick = false) {
                                       QPointF(content->mapToGlobal(background)), button, button,
                                       Qt::NoModifier);
     QCoreApplication::sendEvent(content, &backgroundDoubleClick);
+    require(guarded && window->isVisible(), "OCR background close must wait for button release");
+    releaseCloseGesture(*window, button);
     require(processUntilDeleted(guarded, 2000), "double-clicking OCR drag background must close");
 }
 
@@ -3498,6 +3512,8 @@ void pinnedDoubleClickActions() {
                      [&removed](const auto&, bool remove) { removed = remove; });
     require(settings.setDoubleClickAction(QStringLiteral("close")), "configure Close on thumbnail");
     send(canvas, canvas->rect().center());
+    require(guarded && guarded->isVisible(), "close double-click must leave the thumbnail visible");
+    releaseCloseGesture(*window, Qt::LeftButton);
     require(processUntilDeleted(guarded, 2000) && removed && otherGuard && other->isVisible(),
             "Close must remove only the clicked thumbnail through the user-close lifecycle");
 #if defined(Q_OS_WIN) || defined(_WIN32)
@@ -3509,6 +3525,15 @@ void pinnedDoubleClickActions() {
 #endif
     {
         send(other, other->rect().center());
+    }
+    require(otherGuard && otherGuard->isVisible(), "native double-click must wait for release");
+#if defined(Q_OS_WIN) || defined(_WIN32)
+    if (QGuiApplication::platformName() != QStringLiteral("offscreen")) {
+        SendMessageW(toNativeHwnd(other->winId()), WM_NCLBUTTONUP, HTCAPTION, 0);
+    } else
+#endif
+    {
+        releaseCloseGesture(*other, Qt::LeftButton);
     }
     require(processUntilDeleted(otherGuard, 2000), "Close must also close a normal-sized pin");
 }
@@ -3726,18 +3751,26 @@ void pinnedEscapeBurst(bool nativeKeys = false) {
                 canvas->setFocus();
                 require(QApplication::focusWidget() == canvas, "Escape canvas must own focus");
                 // Exercise the Windows key mapper without global input injection.
-                // The key-up is deliberately lost outside this process after close.
+                // The pin must retain input ownership until the native key-up.
                 const LPARAM keyData =
                     1 | (static_cast<LPARAM>(MapVirtualKeyW(VK_ESCAPE, MAPVK_VK_TO_VSC)) << 16);
                 require(PostMessageW(toNativeHwnd((*it)->winId()), WM_KEYDOWN, VK_ESCAPE,
                                      keyData) != FALSE,
                         "native Escape press failed");
+                waitForUi(30);
+                require(*it && (*it)->isVisible(), "native Escape down must not close the pin");
+                require(PostMessageW(toNativeHwnd((*it)->winId()), WM_KEYUP, VK_ESCAPE,
+                                     keyData | (LPARAM(3) << 30)) != FALSE,
+                        "native Escape release failed");
                 require(processUntilDeleted(*it, 2000),
-                        "one native Escape press must close the active pin");
+                        "native Escape release must close the active pin");
 #endif
             } else {
                 sendShortcut(*canvas, Qt::Key_Escape);
                 sendShortcut(*canvas, Qt::Key_Escape, Qt::NoModifier, true);
+                require(*it && (*it)->isVisible(), "Escape repeats must keep the pin open");
+                QKeyEvent release(QEvent::KeyRelease, Qt::Key_Escape, Qt::NoModifier);
+                QCoreApplication::sendEvent(canvas, &release);
             }
             if (batch % 2 != 0) {
                 require(processUntilDeleted(*it, 2000), "sequential Escape must delete its pin");
@@ -5685,10 +5718,43 @@ void pinnedSaveDialogRoutingAndCancellation() {
     window->close();
     require(processUntilDeleted(guarded, 2000), "pinned save fixture did not close");
 }
+#ifdef Q_OS_WIN
+void pinnedCloseReleaseNative() {
+    close_release_native_test::Receiver receiver;
+    const snow_shot::storage::PinToScreenSettings settings;
+    require(settings.setMiddleMouseButtonAction(QStringLiteral("close")),
+            "configure native middle close");
+    require(settings.setDoubleClickAction(QStringLiteral("close")),
+            "configure native double close");
+    for (const auto button : {Qt::NoButton, Qt::MiddleButton, Qt::LeftButton}) {
+        QImage image(500, 350, QImage::Format_ARGB32_Premultiplied);
+        image.fill(Qt::white);
+        auto* window = new ScreenshotPinnedWindow;
+        QPointer<ScreenshotPinnedWindow> guarded(window);
+        ScreenshotPinnedWindow::Config config;
+        config.nativeGeometry = QRect(150, 150, 500, 350);
+        config.canvasSourceRect = QRectF(image.rect());
+        config.imageSource = ScreenshotImageSource::fromImage(image, config.canvasSourceRect);
+        config.screen = QGuiApplication::primaryScreen();
+        config.automaticTextRecognition = false;
+        require(window->present(config), "present native close test pin");
+        waitForUi(100);
+        receiver.verify(*window, button, button == Qt::LeftButton, button != Qt::NoButton);
+        require(processUntilDeleted(guarded, 2000), "native release must retire the last pin");
+    }
+}
+#endif
+
 } // namespace
 
 int main(int argc, char* argv[]) {
     PinnedWindowTestApplication app(argc, argv);
+#ifdef Q_OS_WIN
+    if (close_release_native_test::receiverRequested()) {
+        return close_release_native_test::runReceiver();
+    }
+#endif
+
     QApplication::setQuitOnLastWindowClosed(false);
 
     try {
@@ -5696,6 +5762,12 @@ int main(int argc, char* argv[]) {
         // without this, lazily initialized storage lands in the developer's
         // real AppData (see IsolatedPinnedStorage).
         IsolatedPinnedStorage processStorage;
+#ifdef Q_OS_WIN
+        if (app.arguments().contains(QStringLiteral("--close-release-native"))) {
+            pinnedCloseReleaseNative();
+            return 0;
+        }
+#endif
         SnowCanvasRuntime sourceRuntime;
         require(sourceRuntime.isValid(), "source runtime creation failed");
         if (app.arguments().contains(QStringLiteral("--scale-readout-only"))) {

--- a/snow_shot/tests/screenshot_recognition_window_tests.cpp
+++ b/snow_shot/tests/screenshot_recognition_window_tests.cpp
@@ -568,6 +568,10 @@ void recognitionWindowUsesOrdinaryQtWindowBehavior() {
     QKeyEvent escape(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
     QApplication::sendEvent(cellEditor, &escape);
     processEditorClose();
+    QKeyEvent escapeRepeat(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier, QString(), true);
+    QApplication::sendEvent(editor, &escapeRepeat);
+    QKeyEvent escapeRelease(QEvent::KeyRelease, Qt::Key_Escape, Qt::NoModifier);
+    QApplication::sendEvent(editor, &escapeRelease);
     require(!editor->isEditingCell() && recognitionCancelCalls == 0,
             "Escape should cancel an active cell edit before reaching screenshot cancellation");
 
@@ -1057,7 +1061,11 @@ void qrContentsUseStrictRichTextLinksAndPreserveOrder() {
 
     QKeyEvent escape(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
     QApplication::sendEvent(browser, &escape);
-    require(escape.isAccepted() && recognitionCancelCalls == 1,
+    require(escape.isAccepted() && recognitionCancelCalls == 0,
+            "Escape press must leave the recognition window open");
+    QKeyEvent escapeRelease(QEvent::KeyRelease, Qt::Key_Escape, Qt::NoModifier);
+    QApplication::sendEvent(browser, &escapeRelease);
+    require(escapeRelease.isAccepted() && recognitionCancelCalls == 1,
             "Escape should remain available while QR results have focus");
 
     window.clearQrContents();

--- a/snow_shot/tests/window_shortcut_manager_tests.cpp
+++ b/snow_shot/tests/window_shortcut_manager_tests.cpp
@@ -59,11 +59,11 @@ void priorityAndFallthroughAreDeterministic() {
     high.canActivate = [&highEnabled](const auto&) { return highEnabled; };
     require(manager.addBinding(&window, std::move(high)) != 0,
             "high-priority binding registration failed");
-    require(manager.addBinding(&window,
-                               binding(QStringLiteral("low"), Qt::Key_K, 100, [&]() {
-                                   ++lowCount;
-                                   return true;
-                               })) != 0,
+    require(manager.addBinding(&window, binding(QStringLiteral("low"), Qt::Key_K, 100,
+                                                [&]() {
+                                                    ++lowCount;
+                                                    return true;
+                                                })) != 0,
             "low-priority binding registration failed");
 
     require(sendKey(&child, QEvent::ShortcutOverride, Qt::Key_K),
@@ -82,16 +82,16 @@ void priorityAndFallthroughAreDeterministic() {
 
     int firstEqualCount = 0;
     int secondEqualCount = 0;
-    require(manager.addBinding(&window,
-                               binding(QStringLiteral("equal-first"), Qt::Key_J, 150, [&]() {
-                                   ++firstEqualCount;
-                                   return false;
-                               })) != 0 &&
-                manager.addBinding(&window,
-                                   binding(QStringLiteral("equal-second"), Qt::Key_J, 150, [&]() {
-                                       ++secondEqualCount;
-                                       return true;
-                                   })) != 0,
+    require(manager.addBinding(&window, binding(QStringLiteral("equal-first"), Qt::Key_J, 150,
+                                                [&]() {
+                                                    ++firstEqualCount;
+                                                    return false;
+                                                })) != 0 &&
+                manager.addBinding(&window, binding(QStringLiteral("equal-second"), Qt::Key_J, 150,
+                                                    [&]() {
+                                                        ++secondEqualCount;
+                                                        return true;
+                                                    })) != 0,
             "equal-priority binding registration failed");
     require(sendKey(&child, QEvent::KeyPress, Qt::Key_J) && firstEqualCount == 1 &&
                 secondEqualCount == 1,
@@ -114,11 +114,9 @@ void scopeRepeatUpdatesAndLifetimeAreEnforced() {
     const auto handle = manager.addBinding(owner, std::move(repeatBinding));
     require(handle != 0, "repeat binding registration failed");
     sendKey(&otherWindow, QEvent::KeyPress, Qt::Key_R);
-    require(count == 0,
-            "shortcut must not escape its window scope");
+    require(count == 0, "shortcut must not escape its window scope");
     sendKey(&scopedChild, QEvent::KeyPress, Qt::Key_R, Qt::NoModifier, true);
-    require(count == 0,
-            "auto-repeat must be disabled by default");
+    require(count == 0, "auto-repeat must be disabled by default");
 
     auto enabledRepeatBinding = binding(QStringLiteral("enabled-repeat"), Qt::Key_U, 100, [&]() {
         ++count;
@@ -130,19 +128,16 @@ void scopeRepeatUpdatesAndLifetimeAreEnforced() {
     require(sendKey(&scopedChild, QEvent::KeyPress, Qt::Key_U, Qt::NoModifier, true) && count == 1,
             "binding with auto-repeat enabled must handle repeated key presses");
 
-    require(manager.setKeyCombinations(handle,
-                                       {QKeyCombination(Qt::NoModifier, Qt::Key_T)}),
+    require(manager.setKeyCombinations(handle, {QKeyCombination(Qt::NoModifier, Qt::Key_T)}),
             "binding update failed");
     sendKey(&scopedChild, QEvent::KeyPress, Qt::Key_R);
-    require(count == 1,
-            "replaced shortcut must stop matching its old key");
+    require(count == 1, "replaced shortcut must stop matching its old key");
     require(sendKey(&scopedChild, QEvent::KeyPress, Qt::Key_T) && count == 2,
             "updated shortcut must match immediately");
 
     delete owner;
     sendKey(&scopedChild, QEvent::KeyPress, Qt::Key_T);
-    require(count == 2,
-            "destroying an owner must unregister its shortcuts");
+    require(count == 2, "destroying an owner must unregister its shortcuts");
 }
 
 void bindingsCanExplicitlyHandleTransientToolWindows() {
@@ -260,21 +255,21 @@ void dispatchSurvivesBindingRemovalFromCallbacks() {
     manager.addScopeWindow(&window);
 
     int lowCount = 0;
-    require(manager.addBinding(&window,
-                               binding(QStringLiteral("removal-low"), Qt::Key_X, 100, [&]() {
-                                   ++lowCount;
-                                   return true;
-                               })) != 0,
+    require(manager.addBinding(&window, binding(QStringLiteral("removal-low"), Qt::Key_X, 100,
+                                                [&]() {
+                                                    ++lowCount;
+                                                    return true;
+                                                })) != 0,
             "low-priority removal binding registration failed");
 
     QObject* transientOwner = new QObject;
-    require(manager.addBinding(
-                transientOwner,
-                binding(QStringLiteral("removal-high"), Qt::Key_X, 200, [&transientOwner]() {
-                    QObject* owner = std::exchange(transientOwner, nullptr);
-                    delete owner;
-                    return false;
-                })) != 0,
+    require(manager.addBinding(transientOwner,
+                               binding(QStringLiteral("removal-high"), Qt::Key_X, 200,
+                                       [&transientOwner]() {
+                                           QObject* owner = std::exchange(transientOwner, nullptr);
+                                           delete owner;
+                                           return false;
+                                       })) != 0,
             "self-removing binding registration failed");
 
     require(sendKey(&window, QEvent::KeyPress, Qt::Key_X) && lowCount == 1 &&
@@ -306,15 +301,13 @@ void heldBindingsReleaseByTriggerKey() {
         ++releaseCount;
         return true;
     };
-    require(manager.addBinding(&window, std::move(held)) != 0,
-            "held chord registration failed");
+    require(manager.addBinding(&window, std::move(held)) != 0, "held chord registration failed");
 
     require(sendKey(&window, QEvent::KeyPress, Qt::Key_Space, Qt::ControlModifier) &&
                 activationCount == 1,
             "modified held shortcut did not activate");
     sendKey(&window, QEvent::KeyRelease, Qt::Key_Space, Qt::ControlModifier, true);
-    require(releaseCount == 0,
-            "an auto-repeat release must not end a physically held shortcut");
+    require(releaseCount == 0, "an auto-repeat release must not end a physically held shortcut");
     sendKey(&window, QEvent::KeyRelease, Qt::Key_Control, Qt::NoModifier);
     require(releaseCount == 0,
             "releasing a chord modifier must not impersonate the physical trigger release");
@@ -325,8 +318,8 @@ void heldBindingsReleaseByTriggerKey() {
     require(releaseCount == 1, "a repeated key release invoked the held callback twice");
 
     int declinedReleaseCount = 0;
-    auto declined = binding(QStringLiteral("declined-held"), Qt::Key_D, 100,
-                            []() { return false; });
+    auto declined =
+        binding(QStringLiteral("declined-held"), Qt::Key_D, 100, []() { return false; });
     declined.cancel = [] {};
     declined.release = [&declinedReleaseCount](const auto&) {
         ++declinedReleaseCount;
@@ -341,8 +334,8 @@ void heldBindingsReleaseByTriggerKey() {
 
     int destroyedReleaseCount = 0;
     auto* owner = new QObject;
-    auto destroyed = binding(QStringLiteral("destroyed-held"), Qt::Key_L, 100,
-                             []() { return true; });
+    auto destroyed =
+        binding(QStringLiteral("destroyed-held"), Qt::Key_L, 100, []() { return true; });
     destroyed.cancel = [] {};
     destroyed.release = [&destroyedReleaseCount](const auto&) {
         ++destroyedReleaseCount;
@@ -400,23 +393,20 @@ void heldModifierParsingAndAdditionalModifiersAreScoped() {
     move.allowedAdditionalModifiers = Qt::ShiftModifier;
     require(manager.addBinding(&window, std::move(move)) != 0,
             "Shift-compatible Space binding registration failed");
-    require(sendKey(&window, QEvent::KeyPress, Qt::Key_Space, Qt::ShiftModifier) &&
-                moveCount == 1,
+    require(sendKey(&window, QEvent::KeyPress, Qt::Key_Space, Qt::ShiftModifier) && moveCount == 1,
             "Shift followed by Space did not activate the contextual held shortcut");
     sendKey(&window, QEvent::KeyPress, Qt::Key_Space, Qt::ControlModifier);
-    require(moveCount == 1,
-            "a contextual binding accepted an undeclared additional modifier");
+    require(moveCount == 1, "a contextual binding accepted an undeclared additional modifier");
 
     int exactCount = 0;
-    require(manager.addBinding(&window,
-                               binding(QStringLiteral("exact-key"), Qt::Key_K, 100, [&]() {
-                                   ++exactCount;
-                                   return true;
-                               })) != 0,
+    require(manager.addBinding(&window, binding(QStringLiteral("exact-key"), Qt::Key_K, 100,
+                                                [&]() {
+                                                    ++exactCount;
+                                                    return true;
+                                                })) != 0,
             "exact binding registration failed");
     sendKey(&window, QEvent::KeyPress, Qt::Key_K, Qt::ShiftModifier);
-    require(exactCount == 0,
-            "ordinary bare shortcuts must retain exact modifier matching");
+    require(exactCount == 0, "ordinary bare shortcuts must retain exact modifier matching");
 }
 
 void inputSuspensionBlocksDispatchAndClearsHeldState() {
@@ -469,11 +459,11 @@ void childWindowOwnershipFallbackKeepsToolbarScope() {
     manager.addScopeWindow(&overlay);
 
     int count = 0;
-    require(manager.addBinding(&overlay,
-                               binding(QStringLiteral("toolbar-child"), Qt::Key_T, 100, [&]() {
-                                   ++count;
-                                   return true;
-                               })) != 0,
+    require(manager.addBinding(&overlay, binding(QStringLiteral("toolbar-child"), Qt::Key_T, 100,
+                                                 [&]() {
+                                                     ++count;
+                                                     return true;
+                                                 })) != 0,
             "toolbar-child binding registration failed");
     require(sendKey(&toolbar, QEvent::KeyPress, Qt::Key_T) && count == 1,
             "a toolbar child did not resolve to its overlay scope");
@@ -505,8 +495,7 @@ void transientToolWindowOwnershipKeepsScope() {
         resolvedScope = context.scopeWindow;
         return true;
     };
-    require(manager.addBinding(&overlay,
-                               std::move(scopedBinding)) != 0,
+    require(manager.addBinding(&overlay, std::move(scopedBinding)) != 0,
             "transient-tool binding registration failed");
     require(sendKey(&popup, QEvent::KeyPress, Qt::Key_P) && count == 1,
             "nested transient tool window did not resolve to its overlay scope");
@@ -533,11 +522,11 @@ void lostKeyReleaseDoesNotSwallowTheNextPress() {
     manager.addScopeWindow(&window);
 
     int count = 0;
-    require(manager.addBinding(&window,
-                               binding(QStringLiteral("completion"), Qt::Key_C, 100, [&]() {
-                                   ++count;
-                                   return true;
-                               })) != 0,
+    require(manager.addBinding(&window, binding(QStringLiteral("completion"), Qt::Key_C, 100,
+                                                [&]() {
+                                                    ++count;
+                                                    return true;
+                                                })) != 0,
             "completion binding registration failed");
 
     require(sendKey(&child, QEvent::KeyPress, Qt::Key_C) && count == 1,
@@ -814,6 +803,179 @@ void cancellationSurvivesBindingRemovalFromCallbacks() {
     sendKey(&window, QEvent::KeyRelease, Qt::Key_F11);
 }
 
+void releaseActivationOwnsTheWholeSequence() {
+    QWidget window;
+    window.show();
+    WindowShortcutManager manager;
+    manager.addScopeWindow(&window);
+    int closes = 0;
+    auto item = binding(QStringLiteral("close-on-release"), Qt::Key_Escape, 100, [&] {
+        ++closes;
+        return true;
+    });
+    item.activationTrigger = WindowShortcutManager::Binding::ActivationTrigger::Release;
+    const auto handle = manager.addBinding(&window, item);
+    require(handle != 0, "release binding must register");
+    require(sendKey(&window, QEvent::KeyPress, Qt::Key_Escape) && closes == 0,
+            "press must reserve closing without executing it");
+    for (int repeat = 0; repeat != 3; ++repeat) {
+        require(sendKey(&window, QEvent::ShortcutOverride, Qt::Key_Escape, Qt::NoModifier, true),
+                "reserved shortcut overrides must be consumed");
+        sendKey(&window, QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier, true);
+        sendKey(&window, QEvent::KeyRelease, Qt::Key_Escape, Qt::NoModifier, true);
+    }
+    sendKey(&window, QEvent::KeyRelease, Qt::Key_Return);
+    require(closes == 0, "repeat and unrelated releases must not close");
+    sendKey(&window, QEvent::KeyRelease, Qt::Key_Escape);
+    sendKey(&window, QEvent::KeyRelease, Qt::Key_Escape);
+    require(closes == 1, "physical release must close exactly once");
+
+    window.activateWindow();
+    window.setFocus();
+    QApplication::processEvents();
+    sendKey(window.windowHandle(), QEvent::KeyPress, Qt::Key_Escape);
+    require(closes == 1, "native QWindow forwarding must reserve the widget's close");
+    sendKey(window.windowHandle(), QEvent::KeyRelease, Qt::Key_Escape);
+    require(closes == 2, "native QWindow release must reach the widget's reserved action");
+
+    require(manager.setKeyCombinations(handle, {QKeyCombination(Qt::ControlModifier, Qt::Key_W)}),
+            "close chord must configure");
+    sendKey(&window, QEvent::KeyPress, Qt::Key_W, Qt::ControlModifier);
+    sendKey(&window, QEvent::KeyRelease, Qt::Key_Control);
+    require(closes == 2, "modifier release must not execute the trigger action");
+    sendKey(&window, QEvent::KeyRelease, Qt::Key_W);
+    require(closes == 3, "trigger release must work after its modifiers were released");
+
+    item.release = [](const auto&) { return true; };
+    item.cancel = [] {};
+    require(manager.addBinding(&window, item) == 0,
+            "release activation cannot also implement a held control");
+}
+
+void interruptedReleaseActivationNeverClosesLater() {
+    for (int scenario = 0; scenario != 6; ++scenario) {
+        QWidget window;
+        window.show();
+        WindowShortcutManager manager;
+        manager.addScopeWindow(&window);
+        QObject owner;
+        bool eligible = true;
+        int closes = 0;
+        auto item = binding(QStringLiteral("cancel-close"), Qt::Key_Escape, 100, [&] {
+            ++closes;
+            return true;
+        });
+        item.activationTrigger = WindowShortcutManager::Binding::ActivationTrigger::Release;
+        item.canActivate = [&](const auto&) { return eligible; };
+        const auto handle = manager.addBinding(&owner, item);
+        sendKey(&window, QEvent::KeyPress, Qt::Key_Escape);
+        switch (scenario) {
+        case 0: {
+            const auto token = manager.suspendInput();
+            manager.resumeInput(token);
+            break;
+        }
+        case 1:
+            manager.removeScopeWindow(&window);
+            break;
+        case 2:
+            require(manager.removeBinding(handle), "binding must remove");
+            break;
+        case 3:
+            require(manager.setKeyCombinations(handle, item.keyCombinations),
+                    "binding must update");
+            break;
+        case 4: {
+            QEvent deactivate(QEvent::ApplicationDeactivate);
+            QCoreApplication::sendEvent(qApp, &deactivate);
+            break;
+        }
+        case 5:
+            eligible = false;
+            break;
+        }
+        sendKey(&window, QEvent::KeyRelease, Qt::Key_Escape);
+        require(closes == 0, "interrupted or ineligible pending close must be discarded");
+    }
+}
+
+void releaseActivationSurvivesToolbarFocusAndManagerDestruction() {
+    QWidget window;
+    QWidget toolbar(&window, Qt::Tool);
+    window.show();
+    toolbar.show();
+    auto manager = std::make_unique<WindowShortcutManager>();
+    manager->addScopeWindow(&window);
+    int closes = 0;
+    auto item = binding(QStringLiteral("destroy-on-release"), Qt::Key_Escape, 100, [&] {
+        ++closes;
+        manager.reset();
+        return true;
+    });
+    item.activationTrigger = WindowShortcutManager::Binding::ActivationTrigger::Release;
+    require(manager->addBinding(&window, item) != 0, "destructive release action must register");
+    sendKey(&window, QEvent::KeyPress, Qt::Key_Escape);
+    toolbar.activateWindow();
+    QApplication::processEvents();
+    sendKey(&toolbar, QEvent::KeyRelease, Qt::Key_Escape);
+    require(closes == 1 && !manager, "toolbar release may safely destroy its shortcut manager");
+}
+
+void contextualCancellationDoesNotEscalateDuringTheSameHold() {
+    QWidget window;
+    window.show();
+    WindowShortcutManager manager;
+    manager.addScopeWindow(&window);
+    bool editing = true;
+    int closes = 0;
+    auto edit = binding(QStringLiteral("cancel-edit"), Qt::Key_Escape, 200, [&] {
+        editing = false;
+        return true;
+    });
+    edit.canActivate = [&](const auto&) { return editing; };
+    edit.release = [](const auto&) { return true; };
+    edit.cancel = [] {};
+    require(manager.addBinding(&window, edit) != 0, "edit cancellation must register");
+    auto close = binding(QStringLiteral("close"), Qt::Key_Escape, 100, [&] {
+        ++closes;
+        return true;
+    });
+    close.activationTrigger = WindowShortcutManager::Binding::ActivationTrigger::Release;
+    require(manager.addBinding(&window, close) != 0, "parent close must register");
+    sendKey(&window, QEvent::KeyPress, Qt::Key_Escape);
+    sendKey(&window, QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier, true);
+    sendKey(&window, QEvent::KeyRelease, Qt::Key_Escape);
+    require(!editing && closes == 0, "canceling editing must not also close its parent");
+    sendKey(&window, QEvent::KeyPress, Qt::Key_Escape);
+    sendKey(&window, QEvent::KeyRelease, Qt::Key_Escape);
+    require(closes == 1, "a fresh close gesture must work after editing ends");
+}
+
+void canceledCloseDoesNotStealAnotherManagersFreshPress() {
+    QWidget first;
+    QWidget second;
+    first.show();
+    second.show();
+    WindowShortcutManager firstManager;
+    WindowShortcutManager secondManager;
+    firstManager.addScopeWindow(&first);
+    secondManager.addScopeWindow(&second);
+    int closes = 0;
+    auto item = binding(QStringLiteral("close"), Qt::Key_Escape, 100, [&] {
+        ++closes;
+        return true;
+    });
+    item.activationTrigger = WindowShortcutManager::Binding::ActivationTrigger::Release;
+    auto owner = std::make_unique<QObject>();
+    require(firstManager.addBinding(owner.get(), item) != 0, "first close must register");
+    require(secondManager.addBinding(&second, item) != 0, "second close must register");
+    sendKey(&first, QEvent::KeyPress, Qt::Key_Escape);
+    owner.reset();
+    sendKey(&second, QEvent::KeyPress, Qt::Key_Escape);
+    sendKey(&second, QEvent::KeyRelease, Qt::Key_Escape);
+    require(closes == 1, "canceled ownership must not steal another window's fresh gesture");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -821,6 +983,11 @@ int main(int argc, char** argv) {
         qputenv("QT_QPA_PLATFORM", "offscreen");
     }
     QApplication application(argc, argv);
+    canceledCloseDoesNotStealAnotherManagersFreshPress();
+    releaseActivationOwnsTheWholeSequence();
+    interruptedReleaseActivationNeverClosesLater();
+    releaseActivationSurvivesToolbarFocusAndManagerDestruction();
+    contextualCancellationDoesNotEscalateDuringTheSameHold();
     cancellationSurvivesBindingRemovalFromCallbacks();
     heldBindingsRequireCancellationAndHandleReentrantSuspension();
     interruptedInputLifecycleIsBalanced();


### PR DESCRIPTION
Add a release activation trigger to WindowShortcutManager bindings and a MouseReleaseActionController that owns press-to-release mouse gestures. Cancel screenshot (Esc), end recording, close pinned window, and overlay right-click cancellation now execute only after the physical release, so an accidental press no longer dismisses the session instantly; focus or capture loss discards the pending action instead of firing it.