### PR TITLE
fix(screenshot): persist previous selection only for committed exports

### DIFF
--- a/snow_shot/include/snow_shot/presentation/screenshothistoryservice.h
+++ b/snow_shot/include/snow_shot/presentation/screenshothistoryservice.h
@@ -27,6 +27,8 @@ struct ScreenshotHistoryServiceContext {
     std::function<void()> presentationChanged = []() {};
     std::function<void(bool)> loadingStateChanged = [](bool) {};
     std::function<void()> intelligentSelectionRequested = []() {};
+    std::function<void(const ScreenshotSelectionParams&)> selectionCommitted =
+        [](const ScreenshotSelectionParams&) {};
 };
 
 class ScreenshotHistoryService final : public QObject {

--- a/snow_shot/src/presentation/selection/screenshotselectionresizeworkflow.cpp
+++ b/snow_shot/src/presentation/selection/screenshotselectionresizeworkflow.cpp
@@ -14,18 +14,6 @@
 
 #include <utility>
 
-namespace {
-void persistPreviousSelectionParams(ScreenshotSelectionSettingsStore& settingsStore,
-                                    const ScreenshotSelectionParams& params, const QRect& bounds) {
-    if (bounds.isEmpty()) {
-        settingsStore.setPreviousSelectionParams(params);
-        return;
-    }
-
-    settingsStore.setPreviousSelectionParams(clampScreenshotSelectionParams(params, bounds));
-}
-} // namespace
-
 ScreenshotSelectionResizeWorkflow::ScreenshotSelectionResizeWorkflow(
     ScreenshotSelectionSettingsStore& settingsStore)
     : m_settingsStore(settingsStore) {}
@@ -86,11 +74,10 @@ bool ScreenshotSelectionResizeWorkflow::open(QObject* modalParent,
                          QCoreApplication::sendEvent(content, &languageChange);
                      });
 
-    const QRect selectionBounds = request.selectionBounds;
     QObject::connect(
         modal, &adqt::widgets::AdModal::closeRequested, modal,
-        [modal, contentGuard, applySelection = std::move(applySelection), settingsStore,
-         selectionBounds](adqt::widgets::AdModal::CloseReason reason) {
+        [modal, contentGuard, applySelection = std::move(applySelection),
+         settingsStore](adqt::widgets::AdModal::CloseReason reason) {
             if (reason != adqt::widgets::AdModal::CloseReason::OkAction) {
                 modal->reject();
                 return;
@@ -115,7 +102,6 @@ bool ScreenshotSelectionResizeWorkflow::open(QObject* modalParent,
             }
             if (result == ScreenshotSelectionResizeModalContent::CommitResult::ApplySelection) {
                 applySelection(params);
-                persistPreviousSelectionParams(*settingsStore, params, selectionBounds);
             }
             modal->accept();
         });

--- a/snow_shot/src/presentation/services/screenshotcontroller.cpp
+++ b/snow_shot/src/presentation/services/screenshotcontroller.cpp
@@ -378,11 +378,11 @@ struct ScreenshotController::Impl final : public ScreenshotToolbarCommandSink,
         std::shared_ptr<ScreenshotExportArtifact> artifact, quint64 generation,
         bool copyFileToClipboard, snow_shot::storage::CaptureHistorySource historySource,
         std::shared_ptr<std::optional<ScreenshotHistoryEntry>> historyCandidate, bool scrolling);
-    void copyArtifactToClipboard(
-        std::shared_ptr<ScreenshotExportArtifact> artifact, quint64 generation,
-        snow_shot::storage::CaptureHistorySource historySource,
-        std::shared_ptr<std::optional<ScreenshotHistoryEntry>> historyCandidate, bool scrolling,
-        std::optional<ScreenshotSelectionParams> selectionToPersist = std::nullopt);
+    void
+    copyArtifactToClipboard(std::shared_ptr<ScreenshotExportArtifact> artifact, quint64 generation,
+                            snow_shot::storage::CaptureHistorySource historySource,
+                            std::shared_ptr<std::optional<ScreenshotHistoryEntry>> historyCandidate,
+                            bool scrolling);
     void completeCopyExport(bool success, quint64 generation,
                             snow_shot::storage::CaptureHistorySource historySource,
                             std::shared_ptr<std::optional<ScreenshotHistoryEntry>> historyCandidate,
@@ -682,6 +682,11 @@ void ScreenshotController::Impl::createHistoryService() {
                 }
                 static_cast<void>(m_selectorWorkflow->updateSelectionAt(
                     m_geometry.physicalPositionForLogicalPoint(m_displaySession, QCursor::pos())));
+            },
+            [this](const ScreenshotSelectionParams& selection) {
+                if (m_selectionSettings != nullptr) {
+                    m_selectionSettings->setPreviousSelectionParams(selection);
+                }
             },
         },
         snow_shot::storage::ApplicationStorage::instance().captureHistory());
@@ -2260,20 +2265,15 @@ void ScreenshotController::Impl::pinSelectionToScreen() {
                     });
             }));
     const QPointer<ScreenshotController> receiver(&owner);
-    const ScreenshotSelectionParams savedSelection = m_selection.params(
-        ScreenshotHalfOpenRect::fromRectF(m_geometry.canvasBounds()).toAlignedQRect());
     const bool presented = m_selectionExportUiServices->presentPinnedArtifact(
         *request, artifact,
-        [receiver, artifact, historyCandidate, savedSelection,
-         generation = *exportGeneration](bool success, QImage) mutable {
+        [receiver, artifact, historyCandidate, generation = *exportGeneration](bool success,
+                                                                               QImage) mutable {
             SNOW_SHOT_PIN_PERF_SCOPE("controller.pin_result_callback");
             SNOW_SHOT_PIN_PERF_FINISH(success);
             if (receiver.isNull() || receiver->m_impl == nullptr ||
                 !receiver->m_impl->finishImageExport(generation)) {
                 return;
-            }
-            if (success && receiver->m_impl->m_selectionSettings != nullptr) {
-                receiver->m_impl->m_selectionSettings->setPreviousSelectionParams(savedSelection);
             }
             if (success && historyCandidate != nullptr && historyCandidate->has_value()) {
                 const bool encodingStarted = artifact->requestCanonicalPng(
@@ -3152,25 +3152,18 @@ void ScreenshotController::Impl::copySelectionToClipboardWithSource(
     }
     const ScreenshotResultStyle style{m_selection.cornerRadius(), m_selection.shadowWidth(),
                                       m_selection.shadowColor()};
-    const QRect selectionBounds =
-        ScreenshotHalfOpenRect::fromRectF(m_geometry.canvasBounds()).toAlignedQRect();
-    const std::optional<ScreenshotSelectionParams> savedSelection =
-        selectionBounds.isEmpty()
-            ? std::nullopt
-            : std::optional<ScreenshotSelectionParams>(m_selection.params(selectionBounds));
     const bool scheduled = m_exportService->requestSelectionResult(
         m_selection.pixelSelection(), style, &owner,
-        [receiver, generation = *exportGeneration, historyCandidate, historySource,
-         savedSelection](QImage image) mutable {
+        [receiver, generation = *exportGeneration, historyCandidate,
+         historySource](QImage image) mutable {
             if (receiver.isNull() || receiver->m_impl == nullptr ||
                 !receiver->m_impl->imageExportCurrent(generation)) {
                 return;
             }
             auto artifact = std::make_shared<ScreenshotExportArtifact>(
                 ScreenshotExportSource::fromImage(std::move(image)));
-            receiver->m_impl->copyArtifactToClipboard(std::move(artifact), generation,
-                                                      historySource, std::move(historyCandidate),
-                                                      false, savedSelection);
+            receiver->m_impl->copyArtifactToClipboard(
+                std::move(artifact), generation, historySource, std::move(historyCandidate), false);
         });
     if (!scheduled) {
         static_cast<void>(finishImageExport(*exportGeneration));
@@ -3295,8 +3288,7 @@ void ScreenshotController::Impl::saveArtifactForCopy(
 void ScreenshotController::Impl::copyArtifactToClipboard(
     std::shared_ptr<ScreenshotExportArtifact> artifact, quint64 generation,
     snow_shot::storage::CaptureHistorySource historySource,
-    std::shared_ptr<std::optional<ScreenshotHistoryEntry>> historyCandidate, bool scrolling,
-    std::optional<ScreenshotSelectionParams> selectionToPersist) {
+    std::shared_ptr<std::optional<ScreenshotHistoryEntry>> historyCandidate, bool scrolling) {
     const QPointer<ScreenshotController> receiver(&owner);
     if (artifact == nullptr || !artifact->isValid()) {
         completeCopyExport(false, generation, historySource, std::move(historyCandidate), scrolling,
@@ -3304,9 +3296,8 @@ void ScreenshotController::Impl::copyArtifactToClipboard(
         return;
     }
     const bool started = artifact->requestClipboard(
-        &owner, [receiver, artifact, generation, historySource, historyCandidate, scrolling,
-                 selectionToPersist = std::move(selectionToPersist)](
-                    ScreenshotExportClipboardResult result) mutable {
+        &owner, [receiver, artifact, generation, historySource, historyCandidate,
+                 scrolling](ScreenshotExportClipboardResult result) mutable {
             if (receiver.isNull() || receiver->m_impl == nullptr ||
                 !receiver->m_impl->imageExportCurrent(generation)) {
                 return;
@@ -3325,9 +3316,8 @@ void ScreenshotController::Impl::copyArtifactToClipboard(
             }
             receiver->m_impl->m_clipboardCommit = ScreenshotClipboardService::commit(
                 QApplication::clipboard(), receiver, std::move(result.payload),
-                [receiver, artifact, generation, historySource, historyCandidate, scrolling,
-                 selectionToPersist = std::move(selectionToPersist)](
-                    ScreenshotClipboardCommitResult commit) mutable {
+                [receiver, artifact, generation, historySource, historyCandidate,
+                 scrolling](ScreenshotClipboardCommitResult commit) mutable {
                     if (receiver.isNull() || receiver->m_impl == nullptr ||
                         !receiver->m_impl->imageExportCurrent(generation)) {
                         return;
@@ -3339,11 +3329,6 @@ void ScreenshotController::Impl::copyArtifactToClipboard(
                             QCoreApplication::translate("ScreenshotController",
                                                         "The screenshot could not be copied: %1")
                                 .arg(commit.errorString()));
-                    }
-                    if (commit.succeeded() && selectionToPersist.has_value() &&
-                        receiver->m_impl->m_selectionSettings != nullptr) {
-                        receiver->m_impl->m_selectionSettings->setPreviousSelectionParams(
-                            *selectionToPersist);
                     }
                     receiver->m_impl->completeCopyExport(commit.succeeded(), generation,
                                                          historySource, historyCandidate, scrolling,

--- a/snow_shot/src/presentation/services/screenshothistoryservice.cpp
+++ b/snow_shot/src/presentation/services/screenshothistoryservice.cpp
@@ -665,6 +665,8 @@ void ScreenshotHistoryService::scheduleWrite(ScreenshotHistoryEntry entry) {
     const QString id = draft.id;
     m_entries.prepend(placeholderRecord(draft));
     m_pendingWrites.push_back(PendingWrite{id, m_validationQueue->submit(std::move(draft))});
+    // Remember the exported snapshot, even if the live editor has since changed or closed.
+    m_context.selectionCommitted(entry.selection);
 }
 
 void ScreenshotHistoryService::reapCompletedWrites() {

--- a/snow_shot/tests/screenshot_history_tests.cpp
+++ b/snow_shot/tests/screenshot_history_tests.cpp
@@ -778,6 +778,49 @@ void multipleValidEntriesCanBeTraversed(const QString& root) {
             "direct return did not restore the live endpoint");
 }
 
+void committedSelectionFollowsHistory(const QString& root) {
+    ScreenshotDisplaySession displays;
+    displays.appendDisplay(display(QStringLiteral("A"), QStringLiteral("Primary"),
+                                   QRect(0, 0, 200, 100),
+                                   solidImage(QSize(200, 100), qRgba(255, 0, 0, 255))));
+    SnowCanvasRuntime runtime;
+    ScreenshotSelectionModel selection;
+    ScreenshotInteractionState interaction;
+    ScreenshotIntelligentSelectionModel intelligent;
+    QVector<ScreenshotSelectionParams> committed;
+    ScreenshotHistoryServiceContext context{displays, runtime, selection, interaction, intelligent};
+    context.selectionCommitted = [&](const ScreenshotSelectionParams& params) {
+        committed.push_back(params);
+    };
+    ScreenshotHistoryService history(std::move(context), root);
+    for (const auto source : {storage::CaptureHistorySource::CopiedToClipboard,
+                              storage::CaptureHistorySource::SavedToFile,
+                              storage::CaptureHistorySource::PinnedToScreen}) {
+        const qsizetype before = committed.size();
+        selection.setSelectionRect(QRect(10 + static_cast<int>(before), 20, 80, 50));
+        auto entry = takeSnapshot(history.snapshotCurrent(true), "history snapshot failed");
+        const ScreenshotSelectionParams exported = entry.selection;
+        require(before == committed.size(), "snapshotting must not remember the selection");
+        selection.setSelectionRect(QRect(100, 5, 30, 20));
+        entry.source = source;
+        history.commit(std::move(entry));
+        require(committed.size() == before + 1 && committed.constLast() == exported,
+                "history commit must remember the exported snapshot for every destination");
+        history.drainPendingWrites();
+    }
+    const auto exportedSelections = committed;
+    auto abandoned = history.snapshotCurrent(true);
+    require(abandoned.has_value(), "abandoned export should have a valid snapshot");
+    history.commit(ScreenshotHistoryEntry{});
+    require(committed == exportedSelections,
+            "uncommitted exports and invalid history must not replace the previous selection");
+    require(history.navigatePrevious(), "history navigation should start");
+    waitForNavigation(history, "history navigation timed out");
+    require(history.returnToCurrentScreenshot(), "live screenshot should be restored");
+    require(committed == exportedSelections,
+            "browsing history must not replace the previous exported selection");
+}
+
 void historyKeysOnlyWorkDuringSelectionStates() {
     ScreenshotCaptureState captureState;
     ScreenshotDisplaySession displays;
@@ -2477,6 +2520,8 @@ int main(int argc, char** argv) {
         storage::ApplicationStorage::instance().shutdown();
         return 0;
     }
+    committedSelectionFollowsHistory(
+        QDir(temporary.path()).filePath(QStringLiteral("committed-selection")));
     navigationMatchesDisplaysAndRestoresLiveEndpoint(
         QDir(temporary.path()).filePath(QStringLiteral("navigation")));
     directCaptureRetainsTheWholeDesktop(QDir(temporary.path()).filePath(QStringLiteral("desktop")));

--- a/snow_shot/tests/screenshot_selection_resize_workflow_tests.cpp
+++ b/snow_shot/tests/screenshot_selection_resize_workflow_tests.cpp
@@ -57,6 +57,42 @@ void selectionResizeModalUsesApplicationModality(ScreenshotSelectionResizeWorkfl
     flushEvents();
 }
 
+void resizingDoesNotReplacePreviousScreenshotSelection(
+    ScreenshotSelectionResizeWorkflow& workflow, ScreenshotSelectionSettingsStore& settingsStore) {
+    for (const bool hasPrevious : {false, true}) {
+        settingsStore.clear();
+        ScreenshotSelectionParams previous;
+        previous.selection = QRect(5, 10, 100, 80);
+        if (hasPrevious) {
+            settingsStore.setPreviousSelectionParams(previous);
+        }
+        QWidget owner;
+        ScreenshotSelectionResizeRequest request;
+        request.currentParams.selection = QRect(20, 30, 320, 180);
+        request.selectionBounds = QRect(0, 0, 1920, 1080);
+        request.ownerWindow = &owner;
+        bool applied = false;
+        require(workflow.open(&owner, request,
+                              [&](const ScreenshotSelectionParams& params) {
+                                  applied = params.selection == request.currentParams.selection;
+                              }),
+                "resize should open for an unexported selection");
+        auto* modal = owner.findChild<adqt::widgets::AdModal*>();
+        require(modal != nullptr && modal->acceptButton() != nullptr,
+                "resize should expose its confirmation action");
+        modal->acceptButton()->click();
+        flushEvents();
+        require(applied, "confirming resize should apply the current selection");
+        require(settingsStore.hasPreviousSelectionParams() == hasPrevious,
+                "resizing must not create a previous screenshot selection");
+        if (hasPrevious) {
+            require(settingsStore.previousSelectionParams() == previous,
+                    "resizing must preserve the previous exported selection");
+        }
+    }
+    settingsStore.clear();
+}
+
 void confirmedPresetCreationPersistsBeforeResizeCloses(
     ScreenshotSelectionResizeWorkflow& workflow, ScreenshotSelectionSettingsStore& settingsStore) {
     QWidget owner;
@@ -180,6 +216,7 @@ int main(int argc, char* argv[]) {
     ScreenshotSelectionResizeWorkflow workflow(settingsStore);
 
     selectionResizeModalUsesApplicationModality(workflow);
+    resizingDoesNotReplacePreviousScreenshotSelection(workflow, settingsStore);
     confirmedPresetCreationPersistsBeforeResizeCloses(workflow, settingsStore);
     presetCreateModalRetranslatesInPlace(workflow, settingsStore);
 


### PR DESCRIPTION
Remember the previous screenshot selection from the snapshot captured when a history entry is written, via a new selectionCommitted callback on ScreenshotHistoryServiceContext, instead of each flow persisting its own state. Resizing a selection, completing a clipboard copy, and presenting a pinned image no longer write previousSelectionParams themselves, so aborted exports, history browsing, and a changed live editor can no longer overwrite the remembered selection with stale state.

Add tests covering per-destination commits, invalid commits, history browsing, and resize confirmation.