### PR TITLE
build(snow-shot): bump version to 1.0.2-beta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 4.2)
 
 project(snow_apps VERSION 0.2.0 LANGUAGES CXX)
 
-set(SNOW_SHOT_VERSION "1.0.1-beta")
+set(SNOW_SHOT_VERSION "1.0.2-beta")
 if(NOT SNOW_SHOT_VERSION MATCHES "^([0-9]+\\.[0-9]+\\.[0-9]+)(-[0-9A-Za-z.-]+)?$")
     message(FATAL_ERROR "SNOW_SHOT_VERSION must be a semantic version such as 0.8.0-dev")
 endif()


### PR DESCRIPTION
Update Snow Shot from `1.0.1-beta` to `1.0.2-beta` for the next beta release.

Changes:
- Update the central `SNOW_SHOT_VERSION` in `CMakeLists.txt`; the numeric version remains derived automatically as `1.0.2`.
- Affects the `snow_shot` target and Snow Shot package metadata across `windows-msvc-debug`, `windows-msvc-performance`, `snow-shot-msvc-release`, and `snow-shot-msvc-fast`.

Validation:
- Passed CMake script validation using the actual version declaration and parsing logic: display version `1.0.2-beta`, numeric version `1.0.2`.
- Passed `git diff --check`.
- C++/Rust format and lint checks are not applicable to this version-only CMake change.
- Application builds and the full test suite were not run; no runtime behavior changed.

Related issues: none.