### PR TITLE
fix(build): detect quoted system codec features in static Qt kits

### DIFF
--- a/cmake/SnowWorkspace.cmake
+++ b/cmake/SnowWorkspace.cmake
@@ -90,12 +90,12 @@ function(snow_workspace_configure_options)
         if(_snow_workspace_qt_gui_text MATCHES
            "add_library\\(Qt6::Gui STATIC IMPORTED\\)")
             if(NOT _snow_workspace_qt_gui_text MATCHES
-               "QT_ENABLED_PRIVATE_FEATURES [^\"]*system_png")
+               "QT_ENABLED_PRIVATE_FEATURES \"[^\"]*system_png")
                 set(SNOW_IMAGE_LINK_PNG_DEPENDENCIES OFF CACHE BOOL
                     "Link the PNG dependency into the static Snow Image target." FORCE)
             endif()
             if(NOT _snow_workspace_qt_gui_text MATCHES
-               "QT_ENABLED_PRIVATE_FEATURES [^\"]*system_jpeg")
+               "QT_ENABLED_PRIVATE_FEATURES \"[^\"]*system_jpeg")
                 set(SNOW_IMAGE_LINK_JPEG_DEPENDENCIES OFF CACHE BOOL
                     "Link JPEG dependencies into the static Snow Image target." FORCE)
             endif()


### PR DESCRIPTION
## Motivation

Since #1126, `cmake --preset snow-shot-msvc-release` fails at configure time on the production static Qt kit (`msvc2026_64-static-system-codecs`):

```
CMake Error ... Failed to find required Qt component "BundledLibjpeg".
```

The kit-introspection in `cmake/SnowWorkspace.cmake` matches `QT_ENABLED_PRIVATE_FEATURES [^\"]*system_jpeg`, but Qt writes the feature list in quotes (`QT_ENABLED_PRIVATE_FEATURES "...;system_jpeg;..."`). Because `[^\"]*` cannot cross the opening quote, the pattern can never match, so every static kit was treated as shipping bundled codecs and `SNOW_IMAGE_LINK_{PNG,JPEG}_DEPENDENCIES` were always forced OFF. That was benign until #1126 made the OFF path run `find_package(Qt6 REQUIRED COMPONENTS BundledLibjpeg)`, which does not exist in the system-codec production kit. Development kits bundle jpeg, so their conclusion (OFF) stays correct and their tests passed.

## Changes

- Anchor both regexes after the opening quote (`QT_ENABLED_PRIVATE_FEATURES \"[^\"]*system_(png|jpeg)`), mirroring `Test-SnowQtSystemCodecKit` in `scripts/package-snow-shot.ps1`, which already matches the quoted form.
- Result: production kit (system zlib/png/jpeg) keeps the normal Snow Image vcpkg codec dependencies, as the surrounding comment already documents; bundled-codec development kits still switch to Qt's bundled codecs.

## Affected presets/targets

- `snow-shot-msvc-release` (behavior changes: configure succeeds again; snow_image links vcpkg PNG/JPEG explicitly).
- `windows-msvc-debug`, `windows-msvc-performance`, `snow-shot-msvc-fast` with the bundled-codec kits: unchanged (flags still OFF).

## Validation

- Script-mode CMake check replicating the fixed condition against both installed kits: release kit resolves PNG=ON/JPEG=ON, development kit resolves PNG=OFF/JPEG=OFF, as expected.
- Full `cmake --fresh --preset snow-shot-msvc-release` through `Set-SnowBuildEnvironment` now configures successfully against `C:/Qt/6.11.1/msvc2026_64-static-system-codecs` (previously the failing step).
- No automated test harness exists for `SnowWorkspace.cmake` detection logic; C++/Rust format and lint are not applicable to this CMake-only change.

Related issues: none