### PR TITLE
fix(release): parse the dumpbin rsds age as decimal

### DIFF
--- a/scripts/collect-snow-shot-symbols.ps1
+++ b/scripts/collect-snow-shot-symbols.ps1
@@ -58,7 +58,7 @@ function Assert-PdbIdentity {
             $stream.Position = [long]$infoBlock * $blockSize + 8
             $pdbAge = $reader.ReadUInt32()
             $pdbSignature = [guid]::new($reader.ReadBytes(16))
-            if ($pdbSignature -ne [guid]$Signature -or $pdbAge -ne [Convert]::ToUInt32($Age, 16)) {
+            if ($pdbSignature -ne [guid]$Signature -or $pdbAge -ne [Convert]::ToUInt32($Age, 10)) {
                 throw "PDB does not match the binary RSDS identity: $Path"
             }
         }
@@ -96,7 +96,7 @@ foreach ($binary in Get-ChildItem -LiteralPath (Join-Path $installRoot "bin") -F
         age = $null
     }
     foreach ($line in $headers) {
-        if ($line -match 'Format:\s+RSDS,\s+\{(?<signature>[0-9A-Fa-f-]+)\},\s+(?<age>[0-9A-Fa-f]+),\s+(?<path>.+\.pdb)\s*$') {
+        if ($line -match 'Format:\s+RSDS,\s+\{(?<signature>[0-9A-Fa-f-]+)\},\s+(?<age>[0-9]+),\s+(?<path>.+\.pdb)\s*$') {
             $record.signature = $Matches.signature
             $record.age = $Matches.age
             $pdb = $Matches.path.Trim()

--- a/scripts/test-snow-shot-release-symbols.ps1
+++ b/scripts/test-snow-shot-release-symbols.ps1
@@ -11,6 +11,34 @@ $null = Set-SnowBuildEnvironment -Preset 'snow-shot-msvc-release'
 & cl /nologo /std:c++20 /O2 /MT /Zi "/Fd:$root/compile.pdb" "/Fo:$root/fixture.obj" "/Fe:$bin/snow_shot.exe" `
     (Join-Path $repo 'snow_shot/tests/update_helper_fixture.cpp') /link /DEBUG "/PDB:$root/fixture.pdb" advapi32.lib
 if ($LASTEXITCODE -ne 0) { throw 'Symbol fixture compilation failed.' }
+# dumpbin reports the RSDS age in decimal. Raise the freshly linked pair's age
+# to a multi-digit value so a hex misreading of the dumpbin field fails here.
+$fixtureExe = [IO.File]::ReadAllBytes((Join-Path $bin 'snow_shot.exe'))
+$rsdsOffset = -1
+for ($i = 0; $i -lt $fixtureExe.Length - 16; $i++) {
+    if ($fixtureExe[$i] -eq 0x52 -and $fixtureExe[$i + 1] -eq 0x53 -and
+        $fixtureExe[$i + 2] -eq 0x44 -and $fixtureExe[$i + 3] -eq 0x53) { $rsdsOffset = $i; break }
+}
+if ($rsdsOffset -lt 0) { throw 'Fixture executable has no RSDS record.' }
+[BitConverter]::GetBytes([uint32]10).CopyTo($fixtureExe, $rsdsOffset + 20)
+[IO.File]::WriteAllBytes((Join-Path $bin 'snow_shot.exe'), $fixtureExe)
+$fixturePdbPath = Join-Path $root 'fixture.pdb'
+$fixturePdb = [IO.File]::ReadAllBytes($fixturePdbPath)
+$guidBytes = [byte[]]::new(16)
+[Array]::Copy($fixtureExe, $rsdsOffset + 4, $guidBytes, 0, 16)
+$pdbAgeOffsets = @()
+for ($i = 4; $i -le $fixturePdb.Length - 20; $i++) {
+    $matchesGuid = $true
+    for ($j = 0; $j -lt 16; $j++) {
+        if ($fixturePdb[$i + $j] -ne $guidBytes[$j]) { $matchesGuid = $false; break }
+    }
+    if ($matchesGuid) { $pdbAgeOffsets += ($i - 4) }
+}
+if ($pdbAgeOffsets.Count -lt 1) { throw 'Fixture PDB identity stream was not found.' }
+foreach ($pdbAgeOffset in $pdbAgeOffsets) {
+    [BitConverter]::GetBytes([uint32]10).CopyTo($fixturePdb, $pdbAgeOffset)
+}
+[IO.File]::WriteAllBytes($fixturePdbPath, $fixturePdb)
 Copy-Item -LiteralPath (Join-Path $bin 'snow_shot.exe') -Destination (Join-Path $bin 'snow-shot-updater.exe')
 Copy-Item -LiteralPath (Join-Path $bin 'snow_shot.exe') -Destination (Join-Path $bin 'snow-ocr-process.exe')
 foreach ($external in @($false, $true)) {


### PR DESCRIPTION
## Motivation

`scripts/collect-snow-shot-symbols.ps1` compared the PDB age returned by `dumpbin /headers` against the PDB info stream using `[Convert]::ToUInt32($Age, 16)`, but dumpbin prints the RSDS age in **decimal**. Any build whose PDB age reached 10 or more therefore failed release packaging with a false `PDB does not match the binary RSDS identity` error, before anything was staged or uploaded. Builds with single-digit ages (fresh PDBs, including every fixture in the existing test) pass in both bases, which is why this went unnoticed until the Snow Shot 1.0.2-beta package attempt: repeated links of that day had pushed `snow_shot.pdb` to age 10 while the executable and PDB identities agreed exactly (verified by reading the PE debug directory and the PDB info stream directly).

## Changes

- `collect-snow-shot-symbols.ps1`: convert the captured age with base 10 and tighten the capture group to `[0-9]+` so the decimal contract is explicit.
- `test-snow-shot-release-symbols.ps1`: raise the freshly linked fixture pair's RSDS age to 10 in both the executable's debug record and the PDB identity stream (all occurrences), so a hex misreading fails the test.

## Affected presets/targets

- `snow-shot-msvc-release` release packaging only (`package-snow-shot.ps1` symbol stage); no application code changed.

## Validation

- `scripts/test-snow-shot-release-symbols.ps1`: all cases pass — matching multi-digit-age PDBs (external OCR false/true) and missing-PDB rejection.
- Real artifacts: `collect-snow-shot-symbols.ps1` now completes against the actual 1.0.2-beta build tree (`snow_shot.pdb` age 10) and produces `snow-shot-symbols-windows-x64.zip`.
- Ground-truth cross-check: the executable's raw debug-directory age, the PDB info-stream age, and dumpbin's printed field all read 10.

Related issues: none