### PR TITLE
perf(recording): start capture sessions off the gui thread

### DIFF
--- a/snow_shot/src/presentation/recording/screenrecordingcontroller.cpp
+++ b/snow_shot/src/presentation/recording/screenrecordingcontroller.cpp
@@ -165,19 +165,32 @@ QString recordingDirectory() {
     return directories.isEmpty() ? QString() : directories.constFirst();
 }
 
-QString recordingFilePath(const QString& extension) {
-    const QString baseName = ScreenshotImageFileService::suggestedBaseName(
-        snow_shot::storage::RecordingSettings().videoFilenameFormat());
-    const QDir directory(recordingDirectory());
+// Runs on the start worker thread: only touches the filesystem, never storage or UI.
+QString chooseRecordingOutputPath(const QStringList& directories, const QString& baseName,
+                                  const QString& extension) {
     const QString normalizedExtension =
         extension.startsWith(QLatin1Char('.')) ? extension : QStringLiteral(".%1").arg(extension);
-    QString path = directory.filePath(baseName + normalizedExtension);
-    for (int suffix = 1; QFileInfo::exists(path); ++suffix) {
-        path = directory.filePath(
-            QStringLiteral("%1_%2%3").arg(baseName).arg(suffix).arg(normalizedExtension));
+    for (const QString& candidate : directories) {
+        QDir directory(candidate);
+        if ((!directory.exists() && !directory.mkpath(QStringLiteral("."))) ||
+            !QFileInfo(directory.absolutePath()).isWritable()) {
+            continue;
+        }
+        QString path = directory.filePath(baseName + normalizedExtension);
+        for (int suffix = 1; QFileInfo::exists(path); ++suffix) {
+            path = directory.filePath(
+                QStringLiteral("%1_%2%3").arg(baseName).arg(suffix).arg(normalizedExtension));
+        }
+        return path;
     }
-    return path;
+    return {};
 }
+
+struct StartAttemptResult {
+    SnowCaptureRecordingSession* session = nullptr;
+    QString outputPath;
+    QString error;
+};
 
 QString captureError() {
     const char* error = snow_capture_last_error_message();
@@ -250,11 +263,23 @@ struct ScreenRecordingController::Impl {
         finalizationPollTimer.setInterval(50);
         QObject::connect(&finalizationPollTimer, &QTimer::timeout, &owner,
                          [this]() { pollFinalization(); });
+        startPollTimer.setInterval(50);
+        QObject::connect(&startPollTimer, &QTimer::timeout, &owner, [this]() { pollStart(); });
     }
 
     ~Impl() {
         durationTimer.stop();
         finalizationPollTimer.stop();
+        startPollTimer.stop();
+        if (startFuture.valid()) {
+            startFuture.wait();
+            // A session that finished starting while the controller was being
+            // destroyed is adopted so the regular destroy path cancels it.
+            if (SnowCaptureRecordingSession* session = startFuture.get().session;
+                session != nullptr && recordingSession == nullptr) {
+                recordingSession = session;
+            }
+        }
         if (finalizationFuture.valid()) {
             finalizationFuture.wait();
             finalizationFuture.get();
@@ -596,26 +621,18 @@ struct ScreenRecordingController::Impl {
             }
             busy = true;
             syncUi();
-            QDir outputDirectory(recordingDirectory());
-            if (!outputDirectory.mkpath(QStringLiteral("."))) {
-                busy = false;
-                syncUi();
-                showError(tr("Unable to create the recording directory"));
-                return;
-            }
 
+            // Snapshot every UI and storage value on the GUI thread; the worker
+            // below must not touch either.
             const snow_shot::storage::RecordingSettings settings;
             sessionOutputSettings = directRecordingSettings(outputFormat, captureRegion.size());
             sessionMouseTrailColor = mouseTrailColor;
             sessionMouseClickColor = mouseClickColor;
             sessionShowCursor = showCursor;
             const bool audioSupported = outputFormat == QStringLiteral("mp4");
-            pendingOutputPath = recordingFilePath(sessionOutputSettings.extension);
-            const QByteArray outputUtf8 = QDir::toNativeSeparators(pendingOutputPath).toUtf8();
-            const RecordingKeyboardLabels keyboardLabels(showKeyboard);
             const RecordingKeyboardTheme keyboardTheme(keyboardBackgroundColor,
                                                        keyboardForegroundColor);
-            const SnowCaptureDirectRecordingConfig config{
+            SnowCaptureDirectRecordingConfig config{
                 SNOW_CAPTURE_DIRECT_RECORDING_CONFIG_VERSION,
                 sizeof(SnowCaptureDirectRecordingConfig),
                 captureRegion.x(),
@@ -624,7 +641,8 @@ struct ScreenRecordingController::Impl {
                 static_cast<uint32_t>(captureRegion.height()),
                 // Auto tries WGC first, then DXGI and GDI on eligible capture failures.
                 static_cast<uint32_t>(SNOW_CAPTURE_BACKEND_AUTO),
-                outputUtf8.constData(),
+                // Bound on the worker thread together with the keyboard labels.
+                nullptr,
                 static_cast<uint32_t>(sessionOutputSettings.format),
                 static_cast<uint32_t>(validRecordingFrameRate(settings.frameRate())),
                 sessionOutputSettings.targetFps,
@@ -646,40 +664,88 @@ struct ScreenRecordingController::Impl {
                 packedRgba(keyboardTheme.background),
                 packedRgba(keyboardTheme.text),
                 packedRgba(keyboardTheme.border),
-                keyboardLabels.entries.constData(),
-                static_cast<uint32_t>(keyboardLabels.entries.size()),
+                nullptr,
+                0,
                 static_cast<uint32_t>(mouseTrailDurationMs),
                 static_cast<uint32_t>(keyboardSize),
             };
-            const SnowCaptureResult createResult =
-                snow_capture_recording_session_create_direct(&config, &recordingSession);
-            if (recordingSession != nullptr && settings.hideToolbarInRecording()) {
+            // Exclude before the worker starts capturing so no frame can ever
+            // contain the toolbar; a failed start restores visibility.
+            if (settings.hideToolbarInRecording()) {
                 excludeToolbarFromCapture();
             }
-            if (createResult != SNOW_CAPTURE_RESULT_OK || recordingSession == nullptr ||
-                snow_capture_recording_session_start(recordingSession) == 0) {
-                const QString error = captureError();
-                if (recordingSession != nullptr) {
-                    snow_capture_recording_session_destroy(recordingSession);
-                    recordingSession = nullptr;
-                }
-                restoreToolbarCaptureVisibility();
+            const QString baseName =
+                ScreenshotImageFileService::suggestedBaseName(settings.videoFilenameFormat());
+            const QStringList directories = recordingDirectories();
+            const QString extension = sessionOutputSettings.extension;
+            const bool keyboard = showKeyboard;
+            // Session creation blocks on capture, audio, hooks, and encoder
+            // initialization; keep it off the GUI thread so the busy state can
+            // paint. The FFI error string is thread-local, so it is read here.
+            startFuture = std::async(
+                std::launch::async,
+                [config, directories, baseName, extension,
+                 keyboard]() mutable -> StartAttemptResult {
+                    StartAttemptResult result;
+                    result.outputPath = chooseRecordingOutputPath(directories, baseName, extension);
+                    if (result.outputPath.isEmpty()) {
+                        result.error =
+                            QCoreApplication::translate("ScreenRecordingController",
+                                                        "Unable to create the recording directory");
+                        return result;
+                    }
+                    const QByteArray outputUtf8 =
+                        QDir::toNativeSeparators(result.outputPath).toUtf8();
+                    const RecordingKeyboardLabels labels(keyboard);
+                    config.output_file_utf8 = outputUtf8.constData();
+                    config.keyboard_labels = labels.entries.constData();
+                    config.keyboard_label_count = static_cast<uint32_t>(labels.entries.size());
+                    const SnowCaptureResult createResult =
+                        snow_capture_recording_session_create_direct(&config, &result.session);
+                    if (createResult != SNOW_CAPTURE_RESULT_OK || result.session == nullptr ||
+                        snow_capture_recording_session_start(result.session) == 0) {
+                        result.error = captureError();
+                        return result;
+                    }
+                    return result;
+                });
+            startPollTimer.start();
+        });
+    }
+
+    void pollStart() {
+        if (!startFuture.valid() ||
+            startFuture.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+            return;
+        }
+        startPollTimer.stop();
+        const StartAttemptResult result = startFuture.get();
+        if (uiSession == nullptr) {
+            // The UI was retired while the backend was starting. A session that
+            // did start is shut down through the regular finalization path.
+            if (result.session != nullptr && result.error.isEmpty()) {
+                recordingSession = result.session;
+                pendingOutputPath = result.outputPath;
+                state = ScreenshotToolPalette::RecordingState::Recording;
                 busy = false;
-                syncUi();
-                if (areaWindow != nullptr) {
-                    areaWindow->show();
-                    areaWindow->raise();
-                }
-                if (toolbarWindow != nullptr) {
-                    toolbarWindow->show();
-                    toolbarWindow->raise();
-                }
-                showError(error);
+                stop(false);
                 return;
             }
-
-            durationMilliseconds = 0;
-            state = ScreenshotToolPalette::RecordingState::Recording;
+            if (result.session != nullptr) {
+                snow_capture_recording_session_destroy(result.session);
+            }
+            restoreToolbarCaptureVisibility();
+            busy = false;
+            if (!result.error.isEmpty()) {
+                report(QStringLiteral("recording.failed"), QtWarningMsg);
+            }
+            return;
+        }
+        if (result.session == nullptr || !result.error.isEmpty()) {
+            if (result.session != nullptr) {
+                snow_capture_recording_session_destroy(result.session);
+            }
+            restoreToolbarCaptureVisibility();
             busy = false;
             syncUi();
             if (areaWindow != nullptr) {
@@ -687,11 +753,28 @@ struct ScreenRecordingController::Impl {
                 areaWindow->raise();
             }
             if (toolbarWindow != nullptr) {
-                toolbarWindow->showAndActivate();
+                toolbarWindow->show();
+                toolbarWindow->raise();
             }
-            durationTimer.start();
-            report(QStringLiteral("recording.started"));
-        });
+            showError(result.error);
+            return;
+        }
+
+        recordingSession = result.session;
+        pendingOutputPath = result.outputPath;
+        durationMilliseconds = 0;
+        state = ScreenshotToolPalette::RecordingState::Recording;
+        busy = false;
+        syncUi();
+        if (areaWindow != nullptr) {
+            areaWindow->show();
+            areaWindow->raise();
+        }
+        if (toolbarWindow != nullptr) {
+            toolbarWindow->showAndActivate();
+        }
+        durationTimer.start();
+        report(QStringLiteral("recording.started"));
     }
 
     void pause() {
@@ -732,7 +815,8 @@ struct ScreenRecordingController::Impl {
         }
 
         durationTimer.stop();
-        durationMilliseconds = 0;
+        // Keep the final duration on screen while the file is finalized;
+        // pollFinalization resets it once the operation completes.
         busy = true;
         syncUi();
         SnowCaptureRecordingSession* session = recordingSession;
@@ -908,7 +992,9 @@ struct ScreenRecordingController::Impl {
     QRect captureRegion;
     QTimer durationTimer;
     QTimer finalizationPollTimer;
+    QTimer startPollTimer;
     std::future<std::pair<bool, QString>> finalizationFuture;
+    std::future<StartAttemptResult> startFuture;
     ScreenshotToolPalette::RecordingState state = ScreenshotToolPalette::RecordingState::Idle;
     qint64 durationMilliseconds = 0;
     QString pendingOutputPath;

--- a/snow_shot/src/presentation/tools/screenshottoolpalette.cpp
+++ b/snow_shot/src/presentation/tools/screenshottoolpalette.cpp
@@ -6207,6 +6207,12 @@ void ScreenshotToolPalette::addRecordingControls(QBoxLayout* layout) {
     m_recordPauseButton = addActionButton("Pause recording", outlined_icons::Pause());
     m_recordResumeButton =
         addActionButton("Resume recording", primaryIcon(custom_outlined_icons::RecordingResume()));
+    // Long-running start/stop operations report through setRecordingBusy(); use
+    // the isolated spinner surface like the other toolbar busy indicators.
+    for (auto* button : {m_recordStartButton, m_recordStopButton}) {
+        button->setBusyIndicatorPresentation(
+            adqt::widgets::AdButton::BusyIndicatorPresentation::IsolatedSurface);
+    }
     layout->addWidget(m_recordStartButton);
     layout->addWidget(m_recordStopButton);
     addItemSpacing();
@@ -6234,6 +6240,8 @@ void ScreenshotToolPalette::addRecordingControls(QBoxLayout* layout) {
         addActionButton("Open recording folder", custom_outlined_icons::RecordingFolder());
     m_recordCloseButton = addActionButton("Close recording", outlined_icons::Close(), true);
     m_recordCopyButton = addActionButton("Copy recording", outlined_icons::Copy());
+    m_recordCopyButton->setBusyIndicatorPresentation(
+        adqt::widgets::AdButton::BusyIndicatorPresentation::IsolatedSurface);
     layout->addWidget(m_recordOpenFolderButton);
     addItemSpacing();
     layout->addWidget(m_recordCloseButton);
@@ -6564,10 +6572,12 @@ void ScreenshotToolPalette::updateRecordingControls() {
     if (m_recordStartButton != nullptr) {
         m_recordStartButton->setVisible(idle);
         m_recordStartButton->setEnabled(idle && !m_recordingBusy);
+        m_recordStartButton->setBusy(idle && m_recordingBusy);
     }
     if (m_recordStopButton != nullptr) {
         m_recordStopButton->setVisible(active);
         m_recordStopButton->setEnabled(active && !m_recordingBusy);
+        m_recordStopButton->setBusy(active && m_recordingBusy);
     }
     if (m_recordPauseButton != nullptr) {
         const bool pauseEnabled = recording && !m_recordingBusy;
@@ -6643,6 +6653,7 @@ void ScreenshotToolPalette::updateRecordingControls() {
                                                  outlined_icons::Copy(), scheme.map.colorPrimary)
                                            : outlined_icons::Copy());
         m_recordCopyButton->setEnabled(copyEnabled);
+        m_recordCopyButton->setBusy(active && m_recordingBusy);
     }
 
     if (visibilityChanged) {

--- a/snow_shot/tests/screen_recording_controller_tests.cpp
+++ b/snow_shot/tests/screen_recording_controller_tests.cpp
@@ -60,13 +60,13 @@ std::unique_ptr<RecordingEffectsSource> testEffectsSource() {
 }
 
 SnowCaptureRecordingSession session;
-int starts = 0;
+std::atomic<int> starts = 0;
 SnowCaptureDirectRecordingConfig lastDirectConfig{};
 std::atomic<int> exports = 0;
 std::shared_future<void> exportGate;
 std::promise<void>* exportEntered = nullptr;
 std::atomic<bool> failExport = false;
-bool failStart = false;
+std::atomic<bool> failStart = false;
 std::atomic<int> destroyedSessions = 0;
 void require(bool condition, const char* message) {
     if (!condition) {
@@ -108,6 +108,15 @@ void waitForIdle(ScreenRecordingController& controller) {
     require(!controller.isRecording(), "controlled finalization must return to idle");
 }
 
+void waitForRecording(ScreenRecordingController& controller) {
+    QElapsedTimer deadline;
+    deadline.start();
+    while (!controller.isRecording() && deadline.elapsed() < 3000) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents, 100);
+    }
+    require(controller.isRecording(), "controlled start must reach the recording state");
+}
+
 int recordingWindowCount() {
     int count = 0;
     for (auto* widget : QApplication::topLevelWidgets()) {
@@ -137,8 +146,7 @@ void closeAndStopHaveIndependentUiLifetimes() {
             const int previousDestroyed = destroyedSessions;
             const int previousErrors = errors.shown;
             controller.startRecording();
-            QCoreApplication::processEvents();
-            require(controller.isRecording(), "fake backend must start");
+            waitForRecording(controller);
             if (close) {
                 // Exercise the native close path as well as the toolbar command.
                 toolbar->close();
@@ -643,6 +651,15 @@ void controllerPreviewTransitions() {
     qApp->installEventFilter(&errors);
     failStart = true;
     controller.startRecording();
+    {
+        // The failed start is reported through the asynchronous start path.
+        QElapsedTimer failureWait;
+        failureWait.start();
+        while (errors.shown == 0 && failureWait.elapsed() < 3000) {
+            QCoreApplication::processEvents(QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents,
+                                            100);
+        }
+    }
     pumpPreview();
     require(!controller.isRecording() && state->active && errors.shown == 1,
             "startup failure must restore a fresh preview after dismissing its modal error");
@@ -650,8 +667,13 @@ void controllerPreviewTransitions() {
     qApp->removeEventFilter(&errors);
     controller.startRecording();
     require(!state->active, "accepted start must stop preview before its queued callback");
+    waitForRecording(controller);
     pumpPreview();
     require(controller.isRecording() && !state->active, "recording must keep preview stopped");
+    auto* previewLabel =
+        area->findChild<QLabel*>(QStringLiteral("screenRecordingMotionPreviewLabel"));
+    require(previewLabel == nullptr || !previewLabel->isVisible(),
+            "native capture must never see the preview label");
     require(previewImage(*area->canvas()).pixelColor(100, 100).alpha() == 0,
             "recording with export settings selected must not retain the idle input surface");
     palette()->recordingPauseRequested();
@@ -967,18 +989,13 @@ extern "C" {
 SnowCaptureResult
 snow_capture_recording_session_create_direct(const SnowCaptureDirectRecordingConfig* config,
                                              SnowCaptureRecordingSession** result) {
+    // Session creation runs on the controller's worker thread: only plain data
+    // may be touched here. The preview label invariant is asserted on the GUI
+    // thread by controllerPreviewTransitions instead.
     lastDirectConfig = *config;
     for (const auto& weak : effectSources) {
         if (const auto source = weak.lock()) {
             require(!source->active, "native creation must follow preview observer shutdown");
-        }
-    }
-    for (auto* widget : QApplication::topLevelWidgets()) {
-        if (auto* area = qobject_cast<ScreenRecordingAreaWindow*>(widget)) {
-            auto* label =
-                area->findChild<QLabel*>(QStringLiteral("screenRecordingMotionPreviewLabel"));
-            require(!label || !label->isVisible(),
-                    "native capture must never see the preview label");
         }
     }
     if (failStart) {
@@ -1210,7 +1227,7 @@ int main(int argc, char** argv) {
         palette()->recordingKeyboardForegroundColorChanged(QColor(240, 230, 220, 200));
         controller.startRecording();
         controller.startRecording();
-        QCoreApplication::processEvents();
+        waitForRecording(controller);
         require(starts == 1 && controller.isRecording(), "a fresh request must start exactly once");
         require(lastDirectConfig.mouse_trail_duration_ms == 2000 &&
                     lastDirectConfig.keyboard_background_rgba == 0x28507880 &&

--- a/snow_shot/tests/screen_recording_toolbar_display_tests.cpp
+++ b/snow_shot/tests/screen_recording_toolbar_display_tests.cpp
@@ -175,6 +175,14 @@ int recordingToolbarAcrossNativeDisplays(bool startCapture) {
     }
     if (startCapture) {
         controller.startRecording();
+        // Starting the real backend is asynchronous; wait for it to finish
+        // before comparing compositor output.
+        QElapsedTimer startWait;
+        startWait.start();
+        while (!controller.isRecording() && startWait.elapsed() < 5000) {
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 20);
+            QThread::msleep(1);
+        }
     }
     settleWindows();
     check(controller.isRecording() == startCapture,

--- a/snow_shot/tests/screenshot_tool_palette_tests.cpp
+++ b/snow_shot/tests/screenshot_tool_palette_tests.cpp
@@ -241,6 +241,9 @@ void recordingControlsRemainLaidOutAcrossStateChanges() {
                                 true,
                                 !busy,
                                 !idle && !busy};
+        // Only the start and stop/copy actions show a spinner while busy.
+        const bool spinning[] = {idle && busy, !idle && busy, false, false,        false,
+                                 false,        false,         false, !idle && busy};
         const QLayout* layout = palette.mainPanel()->layout();
         QRect previous;
         for (int index = 0; index < buttons.size(); ++index) {
@@ -256,6 +259,8 @@ void recordingControlsRemainLaidOutAcrossStateChanges() {
                     "recording control visibility should follow recording state");
             require(button->isEnabled() == enabled[index],
                     "recording control availability should follow recording and busy state");
+            require(button->busy() == spinning[index],
+                    "recording control busy indicator should follow recording and busy state");
             if (visible[index]) {
                 require(!button->visibleRegion().isEmpty() &&
                             palette.mainPanel()->rect().contains(button->geometry()),


### PR DESCRIPTION
Session creation blocks on capture, audio, hook, and encoder initialization; run it on a worker thread polled from the event loop so the busy state can paint. Snapshot UI and storage settings on the GUI thread, exclude the toolbar before the worker starts capturing, adopt or destroy late-starting sessions on close, and keep the final duration on screen while the output file is finalized. Start/stop/copy toolbar buttons now show isolated spinner indicators while busy.