### PR TITLE
fix(pinned): resolve control hover presence from the live cursor instead of queued enter/leave events

### DIFF
--- a/snow_shot/CMakeLists.txt
+++ b/snow_shot/CMakeLists.txt
@@ -3045,6 +3045,15 @@ if(SNOW_SHOT_BUILD_TESTS)
             ENVIRONMENT "QT_QPA_PLATFORM=windows"
             ENVIRONMENT_MODIFICATION
                 "PATH=path_list_prepend:$<TARGET_FILE_DIR:Qt6::Core>")
+        add_test(NAME snow-shot-pinned-pointer-presence-tests
+            COMMAND snow-shot-pinned-window-tests --pointer-presence-only)
+        set_tests_properties(snow-shot-pinned-pointer-presence-tests PROPERTIES
+            LABELS "unit;windows"
+            RUN_SERIAL TRUE
+            TIMEOUT 30
+            ENVIRONMENT "QT_QPA_PLATFORM=windows"
+            ENVIRONMENT_MODIFICATION
+                "PATH=path_list_prepend:$<TARGET_FILE_DIR:Qt6::Core>")
     endif()
     set(_snow_shot_pinned_window_test_names
         snow-shot-pinned-escape-burst-tests

--- a/snow_shot/include/snow_shot/presentation/screenshotpinnedwindow.h
+++ b/snow_shot/include/snow_shot/presentation/screenshotpinnedwindow.h
@@ -197,9 +197,11 @@ class ScreenshotPinnedWindow final : public QWidget {
     void showContextMenu(const QPoint& globalPosition);
     void updateCanvasViewport();
     void updateControlsGeometry();
-    // Re-resolves pointer presence from the live native cursor against the
-    // complete window frame. Returns false when the native query is
-    // unavailable so the caller can fall back to event-derived presence.
+    // Single writer for hover presence: the live native cursor against the
+    // complete window frame. Native mouse messages, queued Enter/Leave, and
+    // passive geometry settlement all resolve through this. Returns false when
+    // the native query is unavailable so the caller can fall back to
+    // event-derived presence.
     bool applyNativePointerPresence();
     void destroyCanvas();
     using MaterializationCallback = std::function<void(bool)>;

--- a/snow_shot/include/snow_shot/presentation/screenshotpinnedwindow.h
+++ b/snow_shot/include/snow_shot/presentation/screenshotpinnedwindow.h
@@ -197,6 +197,10 @@ class ScreenshotPinnedWindow final : public QWidget {
     void showContextMenu(const QPoint& globalPosition);
     void updateCanvasViewport();
     void updateControlsGeometry();
+    // Re-resolves pointer presence from the live native cursor against the
+    // complete window frame. Returns false when the native query is
+    // unavailable so the caller can fall back to event-derived presence.
+    bool applyNativePointerPresence();
     void destroyCanvas();
     using MaterializationCallback = std::function<void(bool)>;
     using PresentationCompletion = std::function<void(bool, QImage)>;

--- a/snow_shot/src/presentation/pinned/screenshotpinnedwindow.cpp
+++ b/snow_shot/src/presentation/pinned/screenshotpinnedwindow.cpp
@@ -82,6 +82,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <optional>
 #include <utility>
 
 #if defined(Q_OS_WIN) || defined(_WIN32)
@@ -1140,7 +1141,15 @@ bool ScreenshotPinnedWindow::event(QEvent* event) {
     const bool pointerPresenceChanged =
         event != nullptr && (event->type() == QEvent::Enter || event->type() == QEvent::Leave);
     if (pointerPresenceChanged) {
-        m_pointerInside = event->type() == QEvent::Enter;
+        // Qt synthesizes Enter/Leave from USER32 client-area leave tracking and
+        // queues them, so a leave can arrive after the pointer crossed into the
+        // window's non-client image surface, and an enter can arrive after the
+        // pointer already left the window. Resolve presence from the live
+        // cursor and fall back to the event only when the native query is
+        // unavailable.
+        if (!applyNativePointerPresence()) {
+            m_pointerInside = event->type() == QEvent::Enter;
+        }
     } else if (event != nullptr && event->type() == QEvent::Hide) {
         m_pointerInside = false;
     }
@@ -1178,6 +1187,9 @@ bool ScreenshotPinnedWindow::event(QEvent* event) {
         }
 #endif
         static_cast<void>(reconcilePassiveNativeGeometry());
+        // Keyboard move shortcuts and restore animations relocate the window
+        // under a stationary pointer, so no mouse message re-evaluates presence.
+        static_cast<void>(applyNativePointerPresence());
     }
     return handled;
 }
@@ -1202,11 +1214,11 @@ bool ScreenshotPinnedWindow::nativeEvent(const QByteArray& eventType, void* mess
 
         // The pinned image surface is exposed as HTCAPTION so a press can
         // start physical window capture. That changes the normal client hover
-        // path into non-client mouse messages, which means Qt may not send the
-        // top-level Enter event that drives the control visibility state.
-        // Track both paths here and keep the state based on the actual HWND
-        // bounds so moving between the image and its client-side controls
-        // does not briefly hide the panel.
+        // path into non-client mouse messages, and USER32's leave tracking,
+        // like Qt's synthesized Enter/Leave, follows the client area. Resolve
+        // every mouse message against the complete HWND bounds so presence
+        // tracks the real pointer; the queued Qt events re-resolve the same
+        // way in event() via applyNativePointerPresence().
         const auto updateNativePointerPresence = [&](UINT message) {
             const bool pointerMove = message == WM_MOUSEMOVE || message == WM_NCMOUSEMOVE;
             const bool pointerLeave = message == WM_MOUSELEAVE || message == WM_NCMOUSELEAVE;
@@ -1228,16 +1240,8 @@ bool ScreenshotPinnedWindow::nativeEvent(const QByteArray& eventType, void* mess
                 havePointerPosition = GetCursorPos(&pointer) != FALSE;
             }
 
-            // Track presence against the complete window frame.  The image surface is
-            // exposed as non-client HTCAPTION, so USER32 sends WM_NCMOUSELEAVE while
-            // crossing between the frame and the client-side controls.  Using only the
-            // client rect briefly reports the pointer as outside and hides the controls.
-            RECT windowRect{};
-            const bool haveWindowRect = GetWindowRect(pinnedHwnd, &windowRect) != FALSE;
             const QRect nativeGeometry =
-                haveWindowRect ? QRect(QPoint(windowRect.left, windowRect.top),
-                                       QPoint(windowRect.right - 1, windowRect.bottom - 1))
-                               : native::currentClientGeometry(reinterpret_cast<WId>(pinnedHwnd));
+                native::currentWindowGeometry(reinterpret_cast<WId>(pinnedHwnd));
             const bool inside = havePointerPosition && nativeGeometry.isValid() &&
                                 nativeGeometry.contains(QPoint(pointer.x, pointer.y));
             if (inside != m_pointerInside) {
@@ -3100,6 +3104,25 @@ void ScreenshotPinnedWindow::updateCanvasViewport() {
     m_viewportCenter = m_resultSurfaceCanvasRect.center();
     m_canvas->setViewportCamera(m_viewportCenter.x(), m_viewportCenter.y(), m_viewportZoom);
     updateRecognitionContentGeometry();
+}
+
+bool ScreenshotPinnedWindow::applyNativePointerPresence() {
+#if defined(Q_OS_WIN) || defined(_WIN32)
+    if (!isVisible()) {
+        return false;
+    }
+    const std::optional<bool> inside = native::pointerInsideWindow(internalWinId());
+    if (!inside.has_value()) {
+        return false;
+    }
+    if (*inside != m_pointerInside) {
+        m_pointerInside = *inside;
+        updateControlsGeometry();
+    }
+    return true;
+#else
+    return false;
+#endif
 }
 
 void ScreenshotPinnedWindow::updateControlsGeometry() {

--- a/snow_shot/src/presentation/pinned/screenshotpinnedwindow.cpp
+++ b/snow_shot/src/presentation/pinned/screenshotpinnedwindow.cpp
@@ -1215,52 +1215,26 @@ bool ScreenshotPinnedWindow::nativeEvent(const QByteArray& eventType, void* mess
         // The pinned image surface is exposed as HTCAPTION so a press can
         // start physical window capture. That changes the normal client hover
         // path into non-client mouse messages, and USER32's leave tracking,
-        // like Qt's synthesized Enter/Leave, follows the client area. Resolve
-        // every mouse message against the complete HWND bounds so presence
-        // tracks the real pointer; the queued Qt events re-resolve the same
-        // way in event() via applyNativePointerPresence().
-        const auto updateNativePointerPresence = [&](UINT message) {
-            const bool pointerMove = message == WM_MOUSEMOVE || message == WM_NCMOUSEMOVE;
-            const bool pointerLeave = message == WM_MOUSELEAVE || message == WM_NCMOUSELEAVE;
-            if (!pointerMove && !pointerLeave) {
-                return;
-            }
-
-            POINT pointer{};
-            bool havePointerPosition = false;
-            if (message == WM_NCMOUSEMOVE) {
-                pointer.x = GET_X_LPARAM(nativeMessage->lParam);
-                pointer.y = GET_Y_LPARAM(nativeMessage->lParam);
-                havePointerPosition = true;
-            } else if (message == WM_MOUSEMOVE) {
-                pointer.x = GET_X_LPARAM(nativeMessage->lParam);
-                pointer.y = GET_Y_LPARAM(nativeMessage->lParam);
-                havePointerPosition = ClientToScreen(pinnedHwnd, &pointer) != FALSE;
-            } else {
-                havePointerPosition = GetCursorPos(&pointer) != FALSE;
-            }
-
-            const QRect nativeGeometry =
-                native::currentWindowGeometry(reinterpret_cast<WId>(pinnedHwnd));
-            const bool inside = havePointerPosition && nativeGeometry.isValid() &&
-                                nativeGeometry.contains(QPoint(pointer.x, pointer.y));
-            if (inside != m_pointerInside) {
-                m_pointerInside = inside;
-                updateControlsGeometry();
-            }
-
+        // like Qt's synthesized Enter/Leave, follows the client area. Mouse
+        // messages only arm leave tracking; presence always re-resolves from
+        // the live cursor through applyNativePointerPresence().
+        const UINT pointerMessage = nativeMessage->message;
+        const bool pointerMove = pointerMessage == WM_MOUSEMOVE || pointerMessage == WM_NCMOUSEMOVE;
+        const bool pointerLeave =
+            pointerMessage == WM_MOUSELEAVE || pointerMessage == WM_NCMOUSELEAVE;
+        if (pointerMove || pointerLeave) {
+            static_cast<void>(applyNativePointerPresence());
             if (pointerMove) {
                 TRACKMOUSEEVENT tracking{};
                 tracking.cbSize = sizeof(tracking);
                 tracking.dwFlags = TME_LEAVE;
-                if (message == WM_NCMOUSEMOVE) {
+                if (pointerMessage == WM_NCMOUSEMOVE) {
                     tracking.dwFlags |= TME_NONCLIENT;
                 }
                 tracking.hwndTrack = pinnedHwnd;
                 TrackMouseEvent(&tracking);
             }
-        };
-        updateNativePointerPresence(nativeMessage->message);
+        }
 
         // Qt and USER32 release capture while handing off a pending drag.
         // WM_EXITSIZEMOVE and mouse release still finish the transaction.

--- a/snow_shot/src/presentation/pinned/screenshotpinnedwindownative.cpp
+++ b/snow_shot/src/presentation/pinned/screenshotpinnedwindownative.cpp
@@ -233,6 +233,42 @@ QRect screenshot_pinned_window_native::currentClientGeometry(WId windowId) {
 #endif
 }
 
+QRect screenshot_pinned_window_native::currentWindowGeometry(WId windowId) {
+#if defined(Q_OS_WIN) || defined(_WIN32)
+    const HWND hwnd = toNativeHwnd(windowId);
+    if (hwnd == nullptr) {
+        return {};
+    }
+
+    RECT windowRect{};
+    if (GetWindowRect(hwnd, &windowRect) != FALSE) {
+        return QRect(QPoint(windowRect.left, windowRect.top),
+                     QPoint(windowRect.right - 1, windowRect.bottom - 1));
+    }
+    return currentClientGeometry(windowId);
+#else
+    Q_UNUSED(windowId);
+    return {};
+#endif
+}
+
+std::optional<bool> screenshot_pinned_window_native::pointerInsideWindow(WId windowId) {
+#if defined(Q_OS_WIN) || defined(_WIN32)
+    POINT pointer{};
+    if (GetCursorPos(&pointer) == FALSE) {
+        return std::nullopt;
+    }
+    const QRect nativeGeometry = currentWindowGeometry(windowId);
+    if (!nativeGeometry.isValid() || nativeGeometry.isEmpty()) {
+        return std::nullopt;
+    }
+    return nativeGeometry.contains(QPoint(pointer.x, pointer.y));
+#else
+    Q_UNUSED(windowId);
+    return std::nullopt;
+#endif
+}
+
 bool screenshot_pinned_window_native::applySystemResizeStyle(WId windowId) {
 #if defined(Q_OS_WIN) || defined(_WIN32)
     const HWND hwnd = toNativeHwnd(windowId);
@@ -336,8 +372,8 @@ bool screenshot_pinned_window_native::applyCursor(Qt::CursorShape shape) {
 #endif
 }
 
-bool screenshot_pinned_window_native::synchronizeClientPaint(
-    WId windowId, PaintSynchronization synchronization) {
+bool screenshot_pinned_window_native::synchronizeClientPaint(WId windowId,
+                                                             PaintSynchronization synchronization) {
 #if defined(Q_OS_WIN) || defined(_WIN32)
     const HWND hwnd = toNativeHwnd(windowId);
     if (hwnd == nullptr) {

--- a/snow_shot/src/presentation/pinned/screenshotpinnedwindownative.h
+++ b/snow_shot/src/presentation/pinned/screenshotpinnedwindownative.h
@@ -8,6 +8,7 @@
 #include <Qt>
 
 #include <memory>
+#include <optional>
 
 namespace screenshot_pinned_window_native {
 class SystemMoveKeyboard final {
@@ -38,6 +39,16 @@ enum class PaintSynchronization {
 applyClientGeometry(WId windowId, const QRect& geometry,
                     GeometryUpdate update = GeometryUpdate::PreserveClientPixels);
 [[nodiscard]] QRect currentClientGeometry(WId windowId);
+// The complete native window frame, which is wider than the client area on
+// Windows because the pinned surface re-applies WS_THICKFRAME. Falls back to
+// the client geometry when the window rect cannot be read.
+[[nodiscard]] QRect currentWindowGeometry(WId windowId);
+// Reports whether the live cursor is inside the window's complete native
+// frame, which is wider than the client area on Windows because the pinned
+// surface re-applies WS_THICKFRAME. Returns std::nullopt when the cursor or
+// the window rect cannot be read so callers can fall back to event-derived
+// pointer presence.
+[[nodiscard]] std::optional<bool> pointerInsideWindow(WId windowId);
 [[nodiscard]] bool applySystemResizeStyle(WId windowId);
 [[nodiscard]] bool activateWindow(WId windowId);
 [[nodiscard]] bool installSynchronizedResize(WId windowId, const bool* interactiveResizeActive);

--- a/snow_shot/tests/screenshot_pinned_window_tests.cpp
+++ b/snow_shot/tests/screenshot_pinned_window_tests.cpp
@@ -88,6 +88,9 @@ void runPinnedOriginalImageTranslationTests();
 // installing the Windows HWND hooks required by present().
 class ScreenshotPinnedWindowTestAccess {
   public:
+    static bool pointerInside(const ScreenshotPinnedWindow& window) {
+        return window.m_pointerInside;
+    }
     static QTimer* showReadout(ScreenshotPinnedWindow& window, bool opacity) {
         window.m_scalePercent = 125;
         window.m_opacityPercent = 80;
@@ -1698,6 +1701,26 @@ QImage waitForClipboardImage(const std::function<bool(const QImage&)>& predicate
 }
 
 void setPinnedWindowHovered(ScreenshotPinnedWindow& window, bool hovered) {
+#if defined(Q_OS_WIN) || defined(_WIN32)
+    // Pointer presence resolves inside nativeEvent from the mouse message
+    // position against the window frame, so the native backend simulates the
+    // production hover path with an NC mouse move inside or outside the
+    // window. The offscreen backend has no native window and keeps the
+    // event-driven simulation.
+    if (QGuiApplication::platformName() == QStringLiteral("windows") &&
+        window.internalWinId() != 0) {
+        const HWND hwnd = reinterpret_cast<HWND>(window.internalWinId());
+        const QRect nativeGeometry = window.currentNativeGeometry();
+        require(nativeGeometry.isValid() && !nativeGeometry.isEmpty(),
+                "hover simulation requires a presented pinned window");
+        const QPoint position =
+            hovered ? nativeGeometry.center() : nativeGeometry.topLeft() - QPoint(1000, 1000);
+        SendMessageW(
+            hwnd, WM_NCMOUSEMOVE, HTCAPTION,
+            MAKELPARAM(static_cast<short>(position.x()), static_cast<short>(position.y())));
+        return;
+    }
+#endif
     if (hovered) {
         const QPointF center(window.rect().center());
         QEnterEvent enter(center, center, QPointF(window.mapToGlobal(center.toPoint())));
@@ -3743,6 +3766,8 @@ void pinnedGeometryQueriesDoNotCreateNativeWindows() {
     QCoreApplication::sendEvent(&window, &enter);
     require(window.internalWinId() == 0,
             "hover delivery must not create an unpresented native window");
+    require(ScreenshotPinnedWindowTestAccess::pointerInside(window),
+            "hover delivery without a native window must keep event-derived presence");
 
     window.show();
     window.close();
@@ -3751,11 +3776,15 @@ void pinnedGeometryQueriesDoNotCreateNativeWindows() {
     }
     require(window.internalWinId() == 0, "the closed fixture must have no native window");
     QCoreApplication::sendEvent(&window, &enter);
+    require(ScreenshotPinnedWindowTestAccess::pointerInside(window),
+            "late hover delivery must fall back to event-derived presence");
     QEvent leave(QEvent::Leave);
     QCoreApplication::sendEvent(&window, &leave);
     static_cast<void>(window.currentNativeGeometry());
     require(window.internalWinId() == 0,
             "late hover and geometry queries must not recreate a closed native window");
+    require(!ScreenshotPinnedWindowTestAccess::pointerInside(window),
+            "leave delivery without a native window must clear event-derived presence");
 
     // Full pin presentation installs HWND hooks and cannot run with the offscreen backend.
     // The Windows registration also exercises passive reconciliation after native destruction.
@@ -3782,6 +3811,99 @@ void pinnedGeometryQueriesDoNotCreateNativeWindows() {
     require(presentedWindow.internalWinId() == 0,
             "passive geometry reconciliation must not recreate a native window");
     presentedWindow.close();
+}
+
+void pinnedControlsPresenceFollowsLiveCursor() {
+    // Regression for the unstable hover reveal: USER32's leave tracking and
+    // Qt's synthesized Enter/Leave both follow the client area and are queued,
+    // while the pinned image surface is non-client. Presence must therefore be
+    // resolved from the live cursor against the complete window frame instead
+    // of the stale event semantics.
+    if (QGuiApplication::platformName() != QStringLiteral("windows")) {
+        return; // The regression needs a real HWND and the system cursor.
+    }
+    const auto settleInto = [](const std::function<bool()>& condition, const char* what) {
+        QElapsedTimer elapsed;
+        elapsed.start();
+        while (elapsed.elapsed() < 2000) {
+            QApplication::processEvents(QEventLoop::AllEvents, 20);
+            if (condition()) {
+                return;
+            }
+            QThread::msleep(1);
+        }
+        require(condition(), what);
+    };
+    const CursorPositionRestorer cursorRestorer;
+    QScreen* screen = QGuiApplication::primaryScreen();
+    require(screen != nullptr, "the pointer presence fixture needs a screen");
+    QImage background(600, 400, QImage::Format_ARGB32_Premultiplied);
+    background.fill(Qt::white);
+    ScreenshotPinnedWindow window;
+    window.setAttribute(Qt::WA_DeleteOnClose, false);
+    ScreenshotPinnedWindow::Config config;
+    config.screen = screen;
+    config.nativeGeometry = physicalPinGeometry(*screen, QPoint(40, 40), background.size());
+    config.canvasSourceRect = QRectF(QPointF(), QSizeF(background.size()));
+    config.imageSource = ScreenshotImageSource::fromImage(background, config.canvasSourceRect);
+    config.automaticTextRecognition = false;
+    require(window.present(config), "the pointer presence fixture must present");
+    waitForUi(200);
+
+    auto* controlsPanel =
+        window.findChild<QFrame*>(QStringLiteral("screenshotPinnedControlsPanel"));
+    require(controlsPanel != nullptr, "the pointer presence fixture needs a controls panel");
+
+    const QRect nativeGeometry = window.currentNativeGeometry();
+    const QPoint outsidePoint =
+        ScreenshotGeometryMapper::physicalRectForScreen(*screen).bottomRight() - QPoint(8, 8);
+    require(!nativeGeometry.contains(outsidePoint),
+            "the pointer presence fixture window must not cover the screen corner");
+
+    setSystemCursorPosition(outsidePoint);
+    settleInto([&] { return !controlsPanel->isVisible(); },
+               "controls must stay hidden while the cursor is outside the window");
+
+    setSystemCursorPosition(nativeGeometry.center());
+    settleInto([&] { return controlsPanel->isVisible(); },
+               "hovering inside the window must reveal the controls");
+
+    // A queued leave delivered while the cursor still rests inside the window
+    // (the observed instability) must not hide the controls.
+    QEvent leave(QEvent::Leave);
+    QCoreApplication::sendEvent(&window, &leave);
+    require(controlsPanel->isVisible(),
+            "a queued leave while the cursor is inside must keep the controls visible");
+
+    // Leaving across the resize frame and the non-client image must hide them.
+    setSystemCursorPosition(outsidePoint);
+    settleInto([&] { return !controlsPanel->isVisible(); },
+               "leaving the window must hide the controls");
+
+    // A queued enter delivered after the pointer already left must not show them.
+    QEnterEvent enter(QPointF(10, 10), QPointF(10, 10), QPointF(10, 10));
+    QCoreApplication::sendEvent(&window, &enter);
+    require(!controlsPanel->isVisible(),
+            "a queued enter while the cursor is outside must keep the controls hidden");
+
+    // Relocating geometry under a stationary pointer (thumbnail transition,
+    // keyboard move, restore animation) produces no mouse message; presence
+    // must be re-evaluated as the geometry settles.
+    setSystemCursorPosition(nativeGeometry.center());
+    settleInto([&] { return controlsPanel->isVisible(); },
+               "hovering inside the window must reveal the controls");
+    auto* thumbnail = window.findChild<QAction*>(QStringLiteral("screenshotPinnedThumbnailAction"));
+    require(thumbnail != nullptr, "the pointer presence fixture needs the thumbnail action");
+    thumbnail->setChecked(true);
+    waitForUi(300);
+    thumbnail->setChecked(false);
+    settleInto(
+        [&] {
+            return window.currentNativeGeometry() == nativeGeometry && controlsPanel->isVisible();
+        },
+        "controls must reappear once geometry settles back under the stationary cursor");
+
+    window.close();
 }
 
 void pinnedEscapeBurst(bool nativeKeys = false) {
@@ -5882,6 +6004,10 @@ int main(int argc, char* argv[]) {
         }
         if (app.arguments().contains(QStringLiteral("--passive-geometry-only"))) {
             pinnedGeometryQueriesDoNotCreateNativeWindows();
+            return 0;
+        }
+        if (app.arguments().contains(QStringLiteral("--pointer-presence-only"))) {
+            pinnedControlsPresenceFollowsLiveCursor();
             return 0;
         }
         if (app.arguments().contains(QStringLiteral("--escape-activation-only"))) {

--- a/snow_shot/tests/screenshot_pinned_window_tests.cpp
+++ b/snow_shot/tests/screenshot_pinned_window_tests.cpp
@@ -1702,19 +1702,32 @@ QImage waitForClipboardImage(const std::function<bool(const QImage&)>& predicate
 
 void setPinnedWindowHovered(ScreenshotPinnedWindow& window, bool hovered) {
 #if defined(Q_OS_WIN) || defined(_WIN32)
-    // Pointer presence resolves inside nativeEvent from the mouse message
-    // position against the window frame, so the native backend simulates the
-    // production hover path with an NC mouse move inside or outside the
-    // window. The offscreen backend has no native window and keeps the
-    // event-driven simulation.
+    // Presence resolves from the live cursor, so the native backend places the
+    // system pointer and then delivers the production NC mouse move. Message
+    // coordinates are not a second source of truth. The offscreen backend has
+    // no native window and keeps the event-driven simulation.
     if (QGuiApplication::platformName() == QStringLiteral("windows") &&
         window.internalWinId() != 0) {
-        const HWND hwnd = reinterpret_cast<HWND>(window.internalWinId());
+        const HWND hwnd = toNativeHwnd(window.internalWinId());
         const QRect nativeGeometry = window.currentNativeGeometry();
         require(nativeGeometry.isValid() && !nativeGeometry.isEmpty(),
                 "hover simulation requires a presented pinned window");
-        const QPoint position =
-            hovered ? nativeGeometry.center() : nativeGeometry.topLeft() - QPoint(1000, 1000);
+        QPoint position = nativeGeometry.center();
+        if (!hovered) {
+            QScreen* screen = window.screen();
+            if (screen == nullptr) {
+                screen = QGuiApplication::primaryScreen();
+            }
+            require(screen != nullptr, "hover simulation requires a screen");
+            position = ScreenshotGeometryMapper::physicalRectForScreen(*screen).bottomRight() -
+                       QPoint(8, 8);
+            if (nativeGeometry.contains(position)) {
+                position = nativeGeometry.topLeft() - QPoint(64, 64);
+            }
+            require(!nativeGeometry.contains(position),
+                    "hover-leave simulation needs a point outside the window");
+        }
+        setSystemCursorPosition(position);
         SendMessageW(
             hwnd, WM_NCMOUSEMOVE, HTCAPTION,
             MAKELPARAM(static_cast<short>(position.x()), static_cast<short>(position.y())));
@@ -3868,6 +3881,14 @@ void pinnedControlsPresenceFollowsLiveCursor() {
     settleInto([&] { return controlsPanel->isVisible(); },
                "hovering inside the window must reveal the controls");
 
+    const HWND hwnd = toNativeHwnd(window.internalWinId());
+    require(hwnd != nullptr, "the pointer presence fixture needs a native window");
+    SendMessageW(
+        hwnd, WM_NCMOUSEMOVE, HTCAPTION,
+        MAKELPARAM(static_cast<short>(outsidePoint.x()), static_cast<short>(outsidePoint.y())));
+    require(controlsPanel->isVisible(),
+            "stale mouse-message coordinates must not hide controls while the cursor is inside");
+
     // A queued leave delivered while the cursor still rests inside the window
     // (the observed instability) must not hide the controls.
     QEvent leave(QEvent::Leave);
@@ -3879,6 +3900,12 @@ void pinnedControlsPresenceFollowsLiveCursor() {
     setSystemCursorPosition(outsidePoint);
     settleInto([&] { return !controlsPanel->isVisible(); },
                "leaving the window must hide the controls");
+
+    SendMessageW(hwnd, WM_NCMOUSEMOVE, HTCAPTION,
+                 MAKELPARAM(static_cast<short>(nativeGeometry.center().x()),
+                            static_cast<short>(nativeGeometry.center().y())));
+    require(!controlsPanel->isVisible(),
+            "stale mouse-message coordinates must not reveal controls while the cursor is outside");
 
     // A queued enter delivered after the pointer already left must not show them.
     QEnterEvent enter(QPointF(10, 10), QPointF(10, 10), QPointF(10, 10));
@@ -4325,12 +4352,10 @@ void pinnedScalingAndAspectLockedResizing(SnowCanvasRuntime&) {
             "ordinary image content should hit the single pinned surface as a caption");
     {
         const CursorPositionRestorer restoreCursorPosition;
-        QCursor::setPos(pinnedWindow->mapToGlobal(pinnedWindow->rect().center()));
-        waitForUi(20);
-
         setPinnedWindowHovered(*pinnedWindow, false);
         require(controlsPanel->isHidden(),
                 "the native caption hover test should start with hidden controls");
+        setSystemCursorPosition(hitTestCenter);
         SendMessage(
             pinnedHwnd, WM_NCMOUSEMOVE, HTCAPTION,
             MAKELPARAM(static_cast<WORD>(hitTestCenter.x()), static_cast<WORD>(hitTestCenter.y())));


### PR DESCRIPTION
Qt's synthesized Enter/Leave events follow the client area and are queued, while the pinned image surface is non-client (HTCAPTION). A leave could arrive after the pointer crossed into the window frame and an enter after it already left, making the pinned controls flicker or stay hidden.

Add native::currentWindowGeometry() and native::pointerInsideWindow(), and re-resolve pointer presence from the live cursor against the complete HWND frame in event() and after passive geometry reconciliation (keyboard move, thumbnail and restore animations), falling back to event-derived presence only when the native query is unavailable.

Register the regression as snow-shot-pinned-pointer-presence-tests and drive the hover simulation through native NC mouse moves on the windows platform.