### PR TITLE
fix(pinned): reveal pinned controls immediately and delay only hiding

### DIFF
--- a/snow_shot/src/presentation/pinned/screenshotpinnedpointerpresence.h
+++ b/snow_shot/src/presentation/pinned/screenshotpinnedpointerpresence.h
@@ -7,7 +7,7 @@
 #include <optional>
 #include <utility>
 
-// Shared stable-presence policy for the pinned controls and the top handle.
+// Reveal immediately; delay hiding for both the pinned controls and the top handle.
 class ScreenshotPinnedPointerPresence final : public QObject {
   public:
     ScreenshotPinnedPointerPresence(QObject* parent, std::function<std::optional<bool>()> resolve,
@@ -17,20 +17,23 @@ class ScreenshotPinnedPointerPresence final : public QObject {
         m_timer.setTimerType(Qt::PreciseTimer);
         m_timer.setInterval(100);
         connect(&m_timer, &QTimer::timeout, this, [this] {
-            if (const auto current = m_resolve(); current && *current != m_pending) {
+            if (const auto current = m_resolve(); current && *current) {
                 update(*current);
                 return;
             }
-            m_inside = m_pending;
+            m_inside = false;
             m_changed(m_inside);
         });
     }
 
     void update(bool inside) {
-        if (inside == m_inside) {
+        if (inside) {
             m_timer.stop();
-        } else if (!m_timer.isActive() || inside != m_pending) {
-            m_pending = inside;
+            if (!m_inside) {
+                m_inside = true;
+                m_changed(true);
+            }
+        } else if (m_inside && !m_timer.isActive()) {
             m_timer.start();
         }
     }
@@ -38,7 +41,6 @@ class ScreenshotPinnedPointerPresence final : public QObject {
     void reset() {
         m_timer.stop();
         m_inside = false;
-        m_pending = false;
     }
 
     QTimer& timer() {
@@ -50,7 +52,6 @@ class ScreenshotPinnedPointerPresence final : public QObject {
     std::function<std::optional<bool>()> m_resolve;
     std::function<void(bool)> m_changed;
     bool m_inside = false;
-    bool m_pending = false;
 };
 
 #endif // SNOW_SHOT_PRESENTATION_SCREENSHOTPINNEDPOINTERPRESENCE_H

--- a/snow_shot/tests/screenshot_pinned_hide_to_top_tests.cpp
+++ b/snow_shot/tests/screenshot_pinned_hide_to_top_tests.cpp
@@ -182,15 +182,16 @@ void debouncedHandlePresence() {
     require(f.timer().interval() == 100 && f.timer().timerType() == Qt::PreciseTimer,
             "handle must share the 100 ms presence policy");
     f.controller.updatePointer(handle);
-    require(!f.owner.isVisible() && f.timer().isActive(), "handle entry must wait");
-    const auto timerId = f.timer().id();
+    require(f.owner.isVisible() && !f.timer().isActive() && f.activations == 1,
+            "handle entry must reveal immediately");
     f.controller.updatePointer(handle);
-    require(f.timer().id() == timerId, "handle motion must not restart the delay");
-    f.controller.updatePointer(outside);
-    require(!f.timer().isActive() && !f.owner.isVisible(), "brief handle entry must cancel");
-    f.pointer(handle);
+    require(f.activations == 1 && !f.timer().isActive(),
+            "repeated handle entry must not reactivate or schedule hiding");
     f.controller.updatePointer(outside);
     require(f.owner.isVisible() && f.timer().isActive(), "handle union exit must wait");
+    const auto timerId = f.timer().id();
+    f.controller.updatePointer(outside);
+    require(f.timer().id() == timerId, "repeated exit must not restart the delay");
     f.controller.updatePointer(f.nativeGeometry.center());
     require(f.owner.isVisible() && !f.timer().isActive(),
             "returning to the image must cancel pending hiding");
@@ -204,22 +205,21 @@ void debouncedHandlePresence() {
     f.pointer(outside);
     require(!f.owner.isVisible(), "stable exit must hide after timeout");
     f.controller.updatePointer(handle);
-    f.cursor = outside;
-    f.expire();
-    require(!f.owner.isVisible(), "timeout must reject a stale handle entry using live cursor");
-    f.cursor.reset();
-    f.controller.updatePointer(handle);
+    require(f.owner.isVisible() && !f.timer().isActive(), "reentry must reveal immediately");
+    f.controller.updatePointer(outside);
     f.controller.setSuppressed(true);
-    require(!f.timer().isActive(), "suppression must cancel pending entry");
+    require(!f.timer().isActive(), "suppression must cancel pending hiding");
     f.controller.setSuppressed(false);
     f.controller.updatePointer(handle);
+    f.controller.updatePointer(outside);
     f.controller.exit();
-    require(!f.timer().isActive(), "exiting hide-to-top must cancel pending entry");
+    require(!f.timer().isActive(), "exiting hide-to-top must cancel pending hiding");
     f.enter();
     f.finish();
     f.controller.updatePointer(handle);
+    f.controller.updatePointer(outside);
     f.controller.shutdown();
-    require(!f.timer().isActive(), "shutdown must cancel pending entry");
+    require(!f.timer().isActive(), "shutdown must cancel pending hiding");
 }
 
 void reservationsAndRestore() {

--- a/snow_shot/tests/screenshot_pinned_window_tests.cpp
+++ b/snow_shot/tests/screenshot_pinned_window_tests.cpp
@@ -4100,8 +4100,8 @@ void pinnedGeometryQueriesDoNotCreateNativeWindows() {
     QCoreApplication::sendEvent(&window, &enter);
     require(window.internalWinId() == 0,
             "hover delivery must not create an unpresented native window");
-    require(ScreenshotPinnedWindowTestAccess::pointerPresenceTimer(window).isActive(),
-            "hover delivery without a native window must schedule event-derived presence");
+    require(ScreenshotPinnedWindowTestAccess::pointerInside(window),
+            "hover delivery without a native window must apply event-derived presence immediately");
 
     window.show();
     window.close();
@@ -4160,29 +4160,28 @@ void pinnedPointerPresenceIsDebounced() {
     QEvent leave(QEvent::Leave);
     require(timer.interval() == 100 && timer.isSingleShot() &&
                 timer.timerType() == Qt::PreciseTimer,
-            "pointer transitions must wait at least 100 ms");
+            "hiding must wait at least 100 ms");
     QCoreApplication::sendEvent(&window, &enter);
-    require(!inside() && timer.isActive(), "enter must not change presence immediately");
-    const auto timerId = timer.id();
+    require(inside() && !timer.isActive(), "enter must reveal controls immediately");
     QCoreApplication::sendEvent(&window, &enter);
-    require(timer.id() == timerId, "repeated enter must not restart the delay");
-    QCoreApplication::sendEvent(&window, &leave);
-    require(!inside() && !timer.isActive(), "brief entry must cancel without revealing controls");
-    QCoreApplication::sendEvent(&window, &enter);
-    expire();
-    require(inside(), "stable entry must commit on timeout");
+    require(inside() && !timer.isActive(), "repeated entry must not schedule hiding");
     QCoreApplication::sendEvent(&window, &leave);
     require(inside() && timer.isActive(), "leave must not change presence immediately");
+    const auto timerId = timer.id();
+    QCoreApplication::sendEvent(&window, &leave);
+    require(timer.id() == timerId, "repeated leave must not restart the delay");
     QCoreApplication::sendEvent(&window, &enter);
     require(inside() && !timer.isActive(), "brief exit must cancel without hiding controls");
     QCoreApplication::sendEvent(&window, &leave);
     expire();
     require(!inside(), "stable exit must commit on timeout");
     QCoreApplication::sendEvent(&window, &enter);
+    QCoreApplication::sendEvent(&window, &leave);
     QEvent hide(QEvent::Hide);
     QCoreApplication::sendEvent(&window, &hide);
     require(!inside() && !timer.isActive(), "hiding must cancel pending presence");
     QCoreApplication::sendEvent(&window, &enter);
+    QCoreApplication::sendEvent(&window, &leave);
     window.close();
     require(!inside() && !timer.isActive(), "closing must cancel pending presence");
 }


### PR DESCRIPTION
Pointer presence no longer debounces entry: hovering a pinned window or the hide-to-top handle reveals the controls right away, while hiding still waits 100 ms and is cancelled by brief exits. Drop the pending entry state and update the pinned window and hide-to-top tests to the new semantics.